### PR TITLE
Allow to override host system timestamp

### DIFF
--- a/lib/binance/session.rb
+++ b/lib/binance/session.rb
@@ -26,8 +26,8 @@ module Binance
       process_request(limit_conn, method, path, params)
     end
 
-    def sign_request(method, path, params: {})
-      process_request(signed_conn, method, path, params)
+    def sign_request(method, path, timestamp, params: {})
+      process_request(signed_conn(timestamp), method, path, params)
     end
 
     private
@@ -74,10 +74,10 @@ module Binance
       end
     end
 
-    def signed_conn
+    def signed_conn(timestamp)
       build_connection do |conn|
         conn.headers['X-MBX-APIKEY'] = @auth.key
-        conn.use Timestamp
+        conn.use Timestamp, timestamp
         conn.use Signature, @auth.secret
       end
     end

--- a/lib/binance/spot.rb
+++ b/lib/binance/spot.rb
@@ -20,6 +20,7 @@ require 'binance/spot/subaccount'
 require 'binance/spot/trade'
 require 'binance/spot/wallet'
 require 'binance/spot/websocket'
+require 'date'
 
 module Binance
   # Spot class includes the following modules:
@@ -56,6 +57,13 @@ module Binance
 
     def initialize(key: '', secret: '', **kwargs)
       @session = Session.new kwargs.merge(key: key, secret: secret)
+    end
+
+    private
+
+    # @return [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
+    def present_timestamp
+      ::DateTime.now.strftime('%Q')
     end
   end
 end

--- a/lib/binance/spot/blvt.rb
+++ b/lib/binance/spot/blvt.rb
@@ -22,16 +22,17 @@ module Binance
       #
       # POST /sapi/v1/blvt/subscribe
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param tokenName [String]
       # @param cost [Float]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#subscribe-blvt-user_data
-      def subscribe(tokenName:, cost:, **kwargs)
+      def subscribe(timestamp = present_timestamp, tokenName:, cost:, **kwargs)
         Binance::Utils::Validation.require_param('tokenName', tokenName)
         Binance::Utils::Validation.require_param('cost', cost)
 
-        @session.sign_request(:post, '/sapi/v1/blvt/subscribe', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/blvt/subscribe', timestamp, params: kwargs.merge(
           tokenName: tokenName,
           cost: cost
         ))
@@ -41,6 +42,7 @@ module Binance
       #
       # GET /sapi/v1/blvt/subscribe/record
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :tokenName
       # @option kwargs [Integer] :id
@@ -49,24 +51,25 @@ module Binance
       # @option kwargs [Integer] :limit
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-subscription-record-user_data
-      def get_subscribe_record(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/blvt/subscribe/record', params: kwargs)
+      def get_subscribe_record(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/blvt/subscribe/record', timestamp, params: kwargs)
       end
 
       # Redeem BLVT (USER_DATA)
       #
       # POST /sapi/v1/blvt/redeem
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param tokenName [String]
       # @param amount [Float]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#redeem-blvt-user_data
-      def redeem(tokenName:, amount:, **kwargs)
+      def redeem(timestamp = present_timestamp, tokenName:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('tokenName', tokenName)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/blvt/redeem', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/blvt/redeem', timestamp, params: kwargs.merge(
           tokenName: tokenName,
           amount: amount
         ))
@@ -76,6 +79,7 @@ module Binance
       #
       # GET /sapi/v1/blvt/redeem/record
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :tokenName
       # @option kwargs [Integer] :id
@@ -84,20 +88,21 @@ module Binance
       # @option kwargs [Integer] :limit
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-redemption-record-user_data
-      def get_redeem_record(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/blvt/redeem/record', params: kwargs)
+      def get_redeem_record(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/blvt/redeem/record', timestamp, params: kwargs)
       end
 
       # Get BLVT User Limit Info (USER_DATA)
       #
       # GET /sapi/v1/blvt/userLimit
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :tokenName
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-blvt-user-limit-info-user_data
-      def user_limit(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/blvt/userLimit', params: kwargs)
+      def user_limit(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/blvt/userLimit', timestamp, params: kwargs)
       end
     end
   end

--- a/lib/binance/spot/bswap.rb
+++ b/lib/binance/spot/bswap.rb
@@ -18,18 +18,20 @@ module Binance
       #
       # GET /sapi/v1/bswap/liquidity
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :poolId
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-liquidity-information-of-a-pool-user_data
-      def get_liquidity_info(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/bswap/liquidity', params: kwargs)
+      def get_liquidity_info(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/bswap/liquidity', timestamp, params: kwargs)
       end
 
       # Add Liquidity (TRADE)
       #
       # POST /sapi/v1/bswap/liquidityAdd
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param poolId [Integer]
       # @param asset [String]
       # @param quantity [Float]
@@ -37,12 +39,12 @@ module Binance
       # @option kwargs [String] :type "Single" to add a single token; "Combination" to add dual tokens. Default "Single"
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#add-liquidity-trade
-      def add_liquidity(poolId:, asset:, quantity:, **kwargs)
+      def add_liquidity(timestamp = present_timestamp, poolId:, asset:, quantity:, **kwargs)
         Binance::Utils::Validation.require_param('poolId', poolId)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('quantity', quantity)
 
-        @session.sign_request(:post, '/sapi/v1/bswap/liquidityAdd', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/bswap/liquidityAdd', timestamp, params: kwargs.merge(
           poolId: poolId,
           asset: asset,
           quantity: quantity
@@ -53,6 +55,7 @@ module Binance
       #
       # POST /sapi/v1/bswap/liquidityRemove
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param poolId [Integer]
       # @param type [String] SINGLE for single asset removal, COMBINATION for combination of all coins removal
       # @param shareAmount [Float]
@@ -60,12 +63,12 @@ module Binance
       # @option kwargs [String Array] :asset Mandatory for single asset removal
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#remove-liquidity-trade
-      def remove_liquidity(poolId:, type:, shareAmount:, **kwargs)
+      def remove_liquidity(timestamp = present_timestamp, poolId:, type:, shareAmount:, **kwargs)
         Binance::Utils::Validation.require_param('poolId', poolId)
         Binance::Utils::Validation.require_param('type', type)
         Binance::Utils::Validation.require_param('shareAmount', shareAmount)
 
-        @session.sign_request(:post, '/sapi/v1/bswap/liquidityRemove', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/bswap/liquidityRemove', timestamp, params: kwargs.merge(
           poolId: poolId,
           type: type,
           shareAmount: shareAmount
@@ -76,6 +79,7 @@ module Binance
       #
       # GET /sapi/v1/bswap/liquidityOps
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :operationId
       # @option kwargs [Integer] :poolId
@@ -85,26 +89,27 @@ module Binance
       # @option kwargs [Integer] :limit default 3, max 100
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-liquidity-operation-record-user_data
-      def get_liquidity_operation_record(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/bswap/liquidityOps', params: kwargs)
+      def get_liquidity_operation_record(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/bswap/liquidityOps', timestamp, params: kwargs)
       end
 
       # Request Quote (USER_DATA)
       #
       # GET /sapi/v1/bswap/quote
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param quoteAsset [String]
       # @param baseAsset [String]
       # @param quoteQty [Float]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#request-quote-user_data
-      def request_quote(quoteAsset:, baseAsset:, quoteQty:, **kwargs)
+      def request_quote(timestamp = present_timestamp, quoteAsset:, baseAsset:, quoteQty:, **kwargs)
         Binance::Utils::Validation.require_param('quoteAsset', quoteAsset)
         Binance::Utils::Validation.require_param('baseAsset', baseAsset)
         Binance::Utils::Validation.require_param('quoteQty', quoteQty)
 
-        @session.sign_request(:get, '/sapi/v1/bswap/quote', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/bswap/quote', timestamp, params: kwargs.merge(
           quoteAsset: quoteAsset,
           baseAsset: baseAsset,
           quoteQty: quoteQty
@@ -115,18 +120,19 @@ module Binance
       #
       # POST /sapi/v1/bswap/swap
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param quoteAsset [String]
       # @param baseAsset [String]
       # @param quoteQty [Float]
       # @param [Hash] kwargs
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#swap-trade
-      def swap(quoteAsset:, baseAsset:, quoteQty:, **kwargs)
+      def swap(timestamp = present_timestamp, quoteAsset:, baseAsset:, quoteQty:, **kwargs)
         Binance::Utils::Validation.require_param('quoteAsset', quoteAsset)
         Binance::Utils::Validation.require_param('baseAsset', baseAsset)
         Binance::Utils::Validation.require_param('quoteQty', quoteQty)
 
-        @session.sign_request(:post, '/sapi/v1/bswap/swap', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/bswap/swap', timestamp, params: kwargs.merge(
           quoteAsset: quoteAsset,
           baseAsset: baseAsset,
           quoteQty: quoteQty
@@ -137,6 +143,7 @@ module Binance
       #
       # GET /sapi/v1/bswap/swap
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :swapId
       # @option kwargs [Integer] :startTime
@@ -147,26 +154,28 @@ module Binance
       # @option kwargs [Integer] :limit
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-swap-history-user_data
-      def get_swap_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/bswap/swap', params: kwargs)
+      def get_swap_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/bswap/swap', timestamp, params: kwargs)
       end
 
       # Get Pool Configure (USER_DATA)
       #
       # GET /sapi/v1/bswap/poolConfigure
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :poolId
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-pool-configure-user_data
-      def get_pool_config(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/bswap/poolConfigure', params: kwargs)
+      def get_pool_config(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/bswap/poolConfigure', timestamp, params: kwargs)
       end
 
       # Add Liquidity Preview (USER_DATA)
       #
       # GET /sapi/v1/bswap/addLiquidityPreview
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param poolId [Integer]
       # @param type [String] "SINGLE" for adding a single token; "COMBINATION" for adding dual tokens
       # @param quoteAsset [String]
@@ -174,13 +183,13 @@ module Binance
       # @param [Hash] kwargs
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#add-liquidity-preview-user_data
-      def add_liquidity_preview(poolId:, type:, quoteAsset:, quoteQty:, **kwargs)
+      def add_liquidity_preview(timestamp = present_timestamp, poolId:, type:, quoteAsset:, quoteQty:, **kwargs)
         Binance::Utils::Validation.require_param('poolId', poolId)
         Binance::Utils::Validation.require_param('type', type)
         Binance::Utils::Validation.require_param('quoteAsset', quoteAsset)
         Binance::Utils::Validation.require_param('quoteQty', quoteQty)
 
-        @session.sign_request(:get, '/sapi/v1/bswap/addLiquidityPreview', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/bswap/addLiquidityPreview', timestamp, params: kwargs.merge(
           poolId: poolId,
           type: type,
           quoteAsset: quoteAsset,
@@ -192,6 +201,7 @@ module Binance
       #
       # GET /sapi/v1/bswap/removeLiquidityPreview
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param poolId [Integer]
       # @param type [String] "SINGLE" for removing a single token; "COMBINATION" for removing dual tokens
       # @param quoteAsset [String]
@@ -199,13 +209,13 @@ module Binance
       # @param [Hash] kwargs
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#remove-liquidity-preview-user_data
-      def remove_liquidity_preview(poolId:, type:, quoteAsset:, shareAmount:, **kwargs)
+      def remove_liquidity_preview(timestamp = present_timestamp, poolId:, type:, quoteAsset:, shareAmount:, **kwargs)
         Binance::Utils::Validation.require_param('poolId', poolId)
         Binance::Utils::Validation.require_param('type', type)
         Binance::Utils::Validation.require_param('quoteAsset', quoteAsset)
         Binance::Utils::Validation.require_param('shareAmount', shareAmount)
 
-        @session.sign_request(:get, '/sapi/v1/bswap/removeLiquidityPreview', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/bswap/removeLiquidityPreview', timestamp, params: kwargs.merge(
           poolId: poolId,
           type: type,
           quoteAsset: quoteAsset,

--- a/lib/binance/spot/c2c.rb
+++ b/lib/binance/spot/c2c.rb
@@ -9,6 +9,7 @@ module Binance
       #
       # GET /sapi/v1/c2c/orderMatch/listUserOrderHistory
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param tradeType [String]
       # @option kwargs [Integer] :startTimestamp
       # @option kwargs [Integer] :endTimestamp
@@ -17,10 +18,10 @@ module Binance
       # @option kwargs [Integer] :recvWindow
       # @option kwargs [Integer] :timestamp
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-c2c-trade-history-user_data
-      def c2c_trade_history(tradeType:, **kwargs)
+      def c2c_trade_history(timestamp = present_timestamp, tradeType:, **kwargs)
         Binance::Utils::Validation.require_param('tradeType', tradeType)
 
-        @session.sign_request(:get, '/sapi/v1/c2c/orderMatch/listUserOrderHistory', params: kwargs.merge(tradeType: tradeType))
+        @session.sign_request(:get, '/sapi/v1/c2c/orderMatch/listUserOrderHistory', timestamp, params: kwargs.merge(tradeType: tradeType))
       end
     end
   end

--- a/lib/binance/spot/fiat.rb
+++ b/lib/binance/spot/fiat.rb
@@ -9,6 +9,7 @@ module Binance
       #
       # GET /sapi/v1/fiat/orders
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param transactionType [String] 0-deposit,1-withdraw
       # @param kwargs [Hash]
       # @option kwargs [Integer] :beginTime If beginTime and endTime are not sent, the recent 30-day data will be returned.
@@ -17,10 +18,10 @@ module Binance
       # @option kwargs [Integer] :rows default 100, max 500
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-fiat-deposit-withdraw-history-user_data
-      def fiat_deposit_withdraw_history(transactionType:, **kwargs)
+      def fiat_deposit_withdraw_history(timestamp = present_timestamp, transactionType:, **kwargs)
         Binance::Utils::Validation.require_param('transactionType', transactionType)
 
-        @session.sign_request(:get, '/sapi/v1/fiat/orders', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/fiat/orders', timestamp, params: kwargs.merge(
           transactionType: transactionType
         ))
       end
@@ -29,6 +30,7 @@ module Binance
       #
       # GET /sapi/v1/fiat/payments
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param transactionType [String] 0-buy,1-sell
       # @param kwargs [Hash]
       # @option kwargs [Integer] :beginTime If beginTime and endTime are not sent, the recent 30-day data will be returned.
@@ -37,10 +39,10 @@ module Binance
       # @option kwargs [Integer] :rows default 100, max 500
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-fiat-payments-history-user_data
-      def fiat_payment_history(transactionType:, **kwargs)
+      def fiat_payment_history(timestamp = present_timestamp, transactionType:, **kwargs)
         Binance::Utils::Validation.require_param('transactionType', transactionType)
 
-        @session.sign_request(:get, '/sapi/v1/fiat/payments', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/fiat/payments', timestamp, params: kwargs.merge(
           transactionType: transactionType
         ))
       end

--- a/lib/binance/spot/futures.rb
+++ b/lib/binance/spot/futures.rb
@@ -11,6 +11,7 @@ module Binance
       #
       # Execute transfer between spot account and futures account.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param amount [Float]
       # @param type [Integer] 1: transfer from spot account to USDT-M futures account. <br>
@@ -20,12 +21,12 @@ module Binance
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#new-future-account-transfer-user_data
-      def futures_account_transfer(asset:, amount:, type:, **kwargs)
+      def futures_account_transfer(timestamp = present_timestamp, asset:, amount:, type:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:post, '/sapi/v1/futures/transfer', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/futures/transfer', timestamp, params: kwargs.merge(
           asset: asset,
           amount: amount,
           type: type
@@ -36,6 +37,7 @@ module Binance
       #
       # GET /sapi/v1/futures/transfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param startTime [Integer]
       # @param kwargs [Hash]
@@ -44,11 +46,11 @@ module Binance
       # @option kwargs [Integer] :size Default:10 Max:100
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-future-account-transaction-history-list-user_data
-      def futures_account_transfer_history(asset:, startTime:, **kwargs)
+      def futures_account_transfer_history(timestamp = present_timestamp, asset:, startTime:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('startTime', startTime)
 
-        @session.sign_request(:get, '/sapi/v1/futures/transfer', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/futures/transfer', timestamp, params: kwargs.merge(
           asset: asset,
           startTime: startTime
         ))
@@ -58,6 +60,7 @@ module Binance
       #
       # POST /sapi/v1/futures/loan/borrow
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param coin [String]
       # @param collateralCoin [String]
       # @param kwargs [Hash]
@@ -65,11 +68,11 @@ module Binance
       # @option kwargs [Float] :collateralAmount Mandatory when amount is empty.
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#borrow-for-cross-collateral-trade
-      def cross_collateral_borrow(coin:, collateralCoin:, **kwargs)
+      def cross_collateral_borrow(timestamp = present_timestamp, coin:, collateralCoin:, **kwargs)
         Binance::Utils::Validation.require_param('coin', coin)
         Binance::Utils::Validation.require_param('collateralCoin', collateralCoin)
 
-        @session.sign_request(:post, '/sapi/v1/futures/loan/borrow', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/futures/loan/borrow', timestamp, params: kwargs.merge(
           coin: coin,
           collateralCoin: collateralCoin
         ))
@@ -79,6 +82,7 @@ module Binance
       #
       # GET /sapi/v1/futures/loan/borrow/history
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :coin
       # @option kwargs [Integer] :startTime
@@ -86,26 +90,27 @@ module Binance
       # @option kwargs [Integer] :limit default 500, max 1000
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cross-collateral-borrow-history-user_data
-      def cross_collateral_borrow_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/futures/loan/borrow/history', params: kwargs)
+      def cross_collateral_borrow_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/futures/loan/borrow/history', timestamp, params: kwargs)
       end
 
       # Repay For Cross-Collateral (TRADE)
       #
       # POST /sapi/v1/futures/loan/repay
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param coin [String]
       # @param collateralCoin [String]
       # @param amount [Float]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#repay-for-cross-collateral-trade
-      def cross_collateral_repay(coin:, collateralCoin:, amount:, **kwargs)
+      def cross_collateral_repay(timestamp = present_timestamp, coin:, collateralCoin:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('coin', coin)
         Binance::Utils::Validation.require_param('collateralCoin', collateralCoin)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/futures/loan/repay', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/futures/loan/repay', timestamp, params: kwargs.merge(
           coin: coin,
           collateralCoin: collateralCoin,
           amount: amount
@@ -116,6 +121,7 @@ module Binance
       #
       # GET /sapi/v1/futures/loan/repay/history
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :coin
       # @option kwargs [Integer] :startTime
@@ -123,38 +129,41 @@ module Binance
       # @option kwargs [Integer] :limit default 500, max 1000
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cross-collateral-repayment-history-user_data
-      def cross_collateral_repay_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/futures/loan/repay/history', params: kwargs)
+      def cross_collateral_repay_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/futures/loan/repay/history', timestamp, params: kwargs)
       end
 
       # Cross-Collateral Wallet (USER_DATA)
       #
       # GET /sapi/v2/futures/loan/wallet
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cross-collateral-wallet-v2-user_data
-      def cross_collateral_wallet(**kwargs)
-        @session.sign_request(:get, '/sapi/v2/futures/loan/wallet', params: kwargs)
+      def cross_collateral_wallet(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v2/futures/loan/wallet', timestamp, params: kwargs)
       end
 
       # Cross-Collateral Information (USER_DATA)
       #
       # GET /sapi/v2/futures/loan/configs
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :loanCoin
       # @option kwargs [String] :collateralCoin
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cross-collateral-information-v2-user_data
-      def cross_collateral_info(**kwargs)
-        @session.sign_request(:get, '/sapi/v2/futures/loan/configs', params: kwargs)
+      def cross_collateral_info(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v2/futures/loan/configs', timestamp, params: kwargs)
       end
 
       # Calculate Rate After Adjust Cross-Collateral LTV (USER_DATA)
       #
       # GET /sapi/v2/futures/loan/calcAdjustLevel
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param loanCoin [String]
       # @param collateralCoin [String]
       # @param amount [Float]
@@ -162,13 +171,13 @@ module Binance
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#calculate-rate-after-adjust-cross-collateral-ltv-v2-user_data
-      def calculate_adjust_rate(loanCoin:, collateralCoin:, amount:, direction:, **kwargs)
+      def calculate_adjust_rate(timestamp = present_timestamp, loanCoin:, collateralCoin:, amount:, direction:, **kwargs)
         Binance::Utils::Validation.require_param('loanCoin', loanCoin)
         Binance::Utils::Validation.require_param('collateralCoin', collateralCoin)
         Binance::Utils::Validation.require_param('amount', amount)
         Binance::Utils::Validation.require_param('direction', direction)
 
-        @session.sign_request(:get, '/sapi/v2/futures/loan/calcAdjustLevel', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v2/futures/loan/calcAdjustLevel', timestamp, params: kwargs.merge(
           loanCoin: loanCoin,
           collateralCoin: collateralCoin,
           amount: amount,
@@ -180,16 +189,17 @@ module Binance
       #
       # GET /sapi/v2/futures/loan/calcMaxAdjustAmount
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param loanCoin [String]
       # @param collateralCoin [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-max-amount-for-adjust-cross-collateral-ltv-v2-user_data
-      def calculate_adjust_max_amount(loanCoin:, collateralCoin:, **kwargs)
+      def calculate_adjust_max_amount(timestamp = present_timestamp, loanCoin:, collateralCoin:, **kwargs)
         Binance::Utils::Validation.require_param('loanCoin', loanCoin)
         Binance::Utils::Validation.require_param('collateralCoin', collateralCoin)
 
-        @session.sign_request(:get, '/sapi/v2/futures/loan/calcMaxAdjustAmount', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v2/futures/loan/calcMaxAdjustAmount', timestamp, params: kwargs.merge(
           loanCoin: loanCoin,
           collateralCoin: collateralCoin
         ))
@@ -199,6 +209,7 @@ module Binance
       #
       # POST /sapi/v2/futures/loan/adjustCollateral
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param loanCoin [String]
       # @param collateralCoin [String]
       # @param amount [Float]
@@ -206,13 +217,13 @@ module Binance
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#adjust-cross-collateral-ltv-v2-trade
-      def adjust_cross_collateral(loanCoin:, collateralCoin:, amount:, direction:, **kwargs)
+      def adjust_cross_collateral(timestamp = present_timestamp, loanCoin:, collateralCoin:, amount:, direction:, **kwargs)
         Binance::Utils::Validation.require_param('loanCoin', loanCoin)
         Binance::Utils::Validation.require_param('collateralCoin', collateralCoin)
         Binance::Utils::Validation.require_param('amount', amount)
         Binance::Utils::Validation.require_param('direction', direction)
 
-        @session.sign_request(:post, '/sapi/v2/futures/loan/adjustCollateral', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v2/futures/loan/adjustCollateral', timestamp, params: kwargs.merge(
           loanCoin: loanCoin,
           collateralCoin: collateralCoin,
           amount: amount,
@@ -226,6 +237,7 @@ module Binance
       #
       # All data will be returned if loanCoin or collateralCoin is not sent
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :loanCoin
       # @option kwargs [String] :collateralCoin
@@ -234,8 +246,8 @@ module Binance
       # @option kwargs [Integer] :limit default 500, max 1000
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#adjust-cross-collateral-ltv-history-user_data
-      def adjust_cross_collateral_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/futures/loan/adjustCollateral/history', params: kwargs)
+      def adjust_cross_collateral_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/futures/loan/adjustCollateral/history', timestamp, params: kwargs)
       end
 
       # Cross-Collateral Liquidation History (USER_DATA)
@@ -244,6 +256,7 @@ module Binance
       #
       # All data will be returned if loanCoin or collateralCoin is not sent
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :loanCoin
       # @option kwargs [String] :collateralCoin
@@ -252,8 +265,8 @@ module Binance
       # @option kwargs [Integer] :limit default 500, max 1000
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cross-collateral-liquidation-history-user_data
-      def cross_collateral_liquidation_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/futures/loan/liquidationHistory', params: kwargs)
+      def cross_collateral_liquidation_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/futures/loan/liquidationHistory', timestamp, params: kwargs)
       end
 
       # Check Collateral Repay Limit (USER_DATA)
@@ -262,16 +275,17 @@ module Binance
       #
       # Check the maximum and minimum limit when repay with collateral.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param coin [String]
       # @param collateralCoin [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#check-collateral-repay-limit-user_data
-      def collateral_repay_limit(coin:, collateralCoin:, **kwargs)
+      def collateral_repay_limit(timestamp = present_timestamp, coin:, collateralCoin:, **kwargs)
         Binance::Utils::Validation.require_param('coin', coin)
         Binance::Utils::Validation.require_param('collateralCoin', collateralCoin)
 
-        @session.sign_request(:get, '/sapi/v1/futures/loan/collateralRepayLimit', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/futures/loan/collateralRepayLimit', timestamp, params: kwargs.merge(
           coin: coin,
           collateralCoin: collateralCoin
         ))
@@ -283,18 +297,19 @@ module Binance
       #
       # Get quote before repay with collateral is mandatory, the quote will be valid within 25 seconds.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param coin [String]
       # @param collateralCoin [String]
       # @param amount [Float]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-collateral-repay-quote-user_data
-      def collateral_repay_quote(coin:, collateralCoin:, amount:, **kwargs)
+      def collateral_repay_quote(timestamp = present_timestamp, coin:, collateralCoin:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('coin', coin)
         Binance::Utils::Validation.require_param('collateralCoin', collateralCoin)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:get, '/sapi/v1/futures/loan/collateralRepay', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/futures/loan/collateralRepay', timestamp, params: kwargs.merge(
           coin: coin,
           collateralCoin: collateralCoin,
           amount: amount
@@ -307,14 +322,15 @@ module Binance
       #
       # Repay with collateral. Get quote before repay with collateral is mandatory, the quote will be valid within 25 seconds.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param quoteId [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#repay-with-collateral-user_data
-      def repay_with_collateral(quoteId:, **kwargs)
+      def repay_with_collateral(timestamp = present_timestamp, quoteId:, **kwargs)
         Binance::Utils::Validation.require_param('quoteId', quoteId)
 
-        @session.sign_request(:post, '/sapi/v1/futures/loan/collateralRepay', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/futures/loan/collateralRepay', timestamp, params: kwargs.merge(
           quoteId: quoteId
         ))
       end
@@ -325,14 +341,15 @@ module Binance
       #
       # Check collateral repayment result.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param quoteId [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#collateral-repayment-result-user_data
-      def repayment_result(quoteId:, **kwargs)
+      def repayment_result(timestamp = present_timestamp, quoteId:, **kwargs)
         Binance::Utils::Validation.require_param('quoteId', quoteId)
 
-        @session.sign_request(:get, '/sapi/v1/futures/loan/collateralRepayResult', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/futures/loan/collateralRepayResult', timestamp, params: kwargs.merge(
           quoteId: quoteId
         ))
       end
@@ -341,6 +358,7 @@ module Binance
       #
       # GET /sapi/v1/futures/loan/interestHistory
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :collateralCoin
       # @option kwargs [Integer] :startTime
@@ -349,8 +367,8 @@ module Binance
       # @option kwargs [Integer] :limit default 500, max 1000
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cross-collateral-interest-history-user_data
-      def cross_collateral_interest_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/futures/loan/interestHistory', params: kwargs)
+      def cross_collateral_interest_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/futures/loan/interestHistory', timestamp, params: kwargs)
       end
     end
   end

--- a/lib/binance/spot/loan.rb
+++ b/lib/binance/spot/loan.rb
@@ -9,6 +9,7 @@ module Binance
       #
       # GET /sapi/v1/loan/income
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @option kwargs [String] :type
       # @option kwargs [Integer] :startTime
@@ -16,10 +17,10 @@ module Binance
       # @option kwargs [Integer] :limit default 20, max 100
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-crypto-loans-income-history-user_data
-      def get_loan_history(asset:, **kwargs)
+      def get_loan_history(timestamp = present_timestamp, asset:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
 
-        @session.sign_request(:get, '/sapi/v1/loan/income', params: kwargs.merge(asset: asset))
+        @session.sign_request(:get, '/sapi/v1/loan/income', timestamp, params: kwargs.merge(asset: asset))
       end
     end
   end

--- a/lib/binance/spot/margin.rb
+++ b/lib/binance/spot/margin.rb
@@ -11,18 +11,19 @@ module Binance
       #
       # Execute transfer between spot account and cross margin account.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param amount [Float]
       # @param type [Integer]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cross-margin-account-transfer-margin
-      def margin_transfer(asset:, amount:, type:, **kwargs)
+      def margin_transfer(timestamp = present_timestamp, asset:, amount:, type:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:post, '/sapi/v1/margin/transfer', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/margin/transfer', timestamp, params: kwargs.merge(
           asset: asset,
           amount: amount,
           type: type
@@ -35,6 +36,7 @@ module Binance
       #
       # Apply for a loan.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param amount [Float]
       # @param kwargs [Hash]
@@ -42,11 +44,11 @@ module Binance
       # @option kwargs [String] :symbol isolated symbol
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-borrow-margin
-      def margin_borrow(asset:, amount:, **kwargs)
+      def margin_borrow(timestamp = present_timestamp, asset:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/margin/loan', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/margin/loan', timestamp, params: kwargs.merge(
           asset: asset,
           amount: amount
         ))
@@ -58,6 +60,7 @@ module Binance
       #
       # Repay loan for margin account.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param amount [Float]
       # @param kwargs [Hash]
@@ -65,11 +68,11 @@ module Binance
       # @option kwargs [String] :symbol isolated symbol
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-repay-margin
-      def margin_repay(asset:, amount:, **kwargs)
+      def margin_repay(timestamp = present_timestamp, asset:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/margin/repay', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/margin/repay', timestamp, params: kwargs.merge(
           asset: asset,
           amount: amount
         ))
@@ -131,6 +134,7 @@ module Binance
       #
       # POST /sapi/v1/margin/order
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param side [String]
       # @param type [String]
@@ -147,12 +151,12 @@ module Binance
       # @option kwargs [String] :timeInForce GTC,IOC,FOK
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-new-order-trade
-      def margin_new_order(symbol:, side:, type:, **kwargs)
+      def margin_new_order(timestamp = present_timestamp, symbol:, side:, type:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
         Binance::Utils::Validation.require_param('side', side)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:post, '/sapi/v1/margin/order', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/margin/order', timestamp, params: kwargs.merge(
           symbol: symbol,
           side: side,
           type: type
@@ -163,6 +167,7 @@ module Binance
       #
       # DELETE /sapi/v1/margin/order
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :isIsolated for isolated margin or not, "TRUE", "FALSE", default "FALSE"
@@ -171,10 +176,10 @@ module Binance
       # @option kwargs [String] :newClientOrderId
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-new-order-trade
-      def margin_cancel_order(symbol:, **kwargs)
+      def margin_cancel_order(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:delete, '/sapi/v1/margin/order', params: kwargs.merge(
+        @session.sign_request(:delete, '/sapi/v1/margin/order', timestamp, params: kwargs.merge(
           symbol: symbol
         ))
       end
@@ -183,15 +188,16 @@ module Binance
       #
       # DELETE /sapi/v1/margin/openOrders
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :isIsolated for isolated margin or not, "TRUE", "FALSE", default "FALSE"
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-cancel-all-open-orders-on-a-symbol-trade
-      def margin_cancel_all_order(symbol:, **kwargs)
+      def margin_cancel_all_order(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:delete, '/sapi/v1/margin/openOrders', params: kwargs.merge(
+        @session.sign_request(:delete, '/sapi/v1/margin/openOrders', timestamp, params: kwargs.merge(
           symbol: symbol
         ))
       end
@@ -200,6 +206,7 @@ module Binance
       #
       # GET /sapi/v1/margin/transfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
       # @option kwargs [String] :type
@@ -210,14 +217,15 @@ module Binance
       # @option kwargs [String] :archived Default: false. Set to true for archived data from 6 months ago
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-cross-margin-transfer-history-user_data
-      def margin_transfer_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/transfer', params: kwargs)
+      def margin_transfer_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/transfer', timestamp, params: kwargs)
       end
 
       # Query Loan Record (USER_DATA)
       #
       # GET /sapi/v1/margin/loan
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :isolatedSymbol
@@ -229,16 +237,17 @@ module Binance
       # @option kwargs [String] :archived Default: false. Set to true for archived data from 6 months ago
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-loan-record-user_data
-      def margin_load_record(asset:, **kwargs)
+      def margin_load_record(timestamp = present_timestamp, asset:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
 
-        @session.sign_request(:get, '/sapi/v1/margin/loan', params: kwargs.merge(asset: asset))
+        @session.sign_request(:get, '/sapi/v1/margin/loan', timestamp, params: kwargs.merge(asset: asset))
       end
 
       # Query Repay Record (USER_DATA)
       #
       # GET /sapi/v1/margin/repay
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :isolatedSymbol
@@ -250,16 +259,17 @@ module Binance
       # @option kwargs [String] :archived Default: false. Set to true for archived data from 6 months ago
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-repay-record-user_data
-      def margin_repay_record(asset:, **kwargs)
+      def margin_repay_record(timestamp = present_timestamp, asset:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
 
-        @session.sign_request(:get, '/sapi/v1/margin/repay', params: kwargs.merge(asset: asset))
+        @session.sign_request(:get, '/sapi/v1/margin/repay', timestamp, params: kwargs.merge(asset: asset))
       end
 
       # Get Interest History (USER_DATA)
       #
       # GET /sapi/v1/margin/interestHistory
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
       # @option kwargs [String] :isolatedSymbol
@@ -270,14 +280,15 @@ module Binance
       # @option kwargs [String] :archived Default: false. Set to true for archived data from 6 months ago
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-interest-history-user_data
-      def margin_interest_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/interestHistory', params: kwargs)
+      def margin_interest_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/interestHistory', timestamp, params: kwargs)
       end
 
       # Get Force Liquidation Record (USER_DATA)
       #
       # GET /sapi/v1/margin/forceLiquidationRec
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :isolatedSymbol
       # @option kwargs [Integer] :startTime
@@ -286,25 +297,27 @@ module Binance
       # @option kwargs [Integer] :size Default:10 Max:100
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-force-liquidation-record-user_data
-      def margin_force_liquidation_record(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/forceLiquidationRec', params: kwargs)
+      def margin_force_liquidation_record(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/forceLiquidationRec', timestamp, params: kwargs)
       end
 
       # Query Cross Margin Account Details (USER_DATA)
       #
       # GET /sapi/v1/margin/account
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-cross-margin-account-details-user_data
-      def margin_account(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/account', params: kwargs)
+      def margin_account(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/account', timestamp, params: kwargs)
       end
 
       # Query Margin Account's Order (USER_DATA)
       #
       # GET /sapi/v1/margin/order
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :isIsolated for isolated margin or not, "TRUE", "FALSE", default "FALSE"
@@ -312,29 +325,31 @@ module Binance
       # @option kwargs [String] :origClientOrderId
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-order-user_data
-      def margin_order(symbol:, **kwargs)
+      def margin_order(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:get, '/sapi/v1/margin/order', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:get, '/sapi/v1/margin/order', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Query Margin Account's Open Order (USER_DATA)
       #
       # GET /sapi/v1/margin/openOrders
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :symbol
       # @option kwargs [String] :isIsolated for isolated margin or not, "TRUE", "FALSE", default "FALSE"
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-open-orders-user_data
-      def margin_open_orders(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/openOrders', params: kwargs)
+      def margin_open_orders(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/openOrders', timestamp, params: kwargs)
       end
 
       # Query Margin Account's All Order (USER_DATA)
       #
       # GET /sapi/v1/margin/allOrders
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :isIsolated for isolated margin or not, "TRUE", "FALSE", default "FALSE"
@@ -344,16 +359,17 @@ module Binance
       # @option kwargs [Integer] :limit Default 500; max 1000.
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-all-orders-user_data
-      def margin_all_orders(symbol:, **kwargs)
+      def margin_all_orders(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:get, '/sapi/v1/margin/allOrders', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:get, '/sapi/v1/margin/allOrders', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Margin Account New OCO (TRADE)
       #
       # POST /sapi/v1/margin/order/oco
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param side [String]
       # @param quantity [Float]
@@ -372,14 +388,14 @@ module Binance
       # @option kwargs [String] :sideEffectType NO_SIDE_EFFECT, MARGIN_BUY, AUTO_REPAY; default NO_SIDE_EFFECT.
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-new-oco-trade
-      def margin_oco_order(symbol:, side:, quantity:, price:, stopPrice:, **kwargs)
+      def margin_oco_order(timestamp = present_timestamp, symbol:, side:, quantity:, price:, stopPrice:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
         Binance::Utils::Validation.require_param('side', side)
         Binance::Utils::Validation.require_param('quantity', quantity)
         Binance::Utils::Validation.require_param('price', price)
         Binance::Utils::Validation.require_param('stopPrice', stopPrice)
 
-        @session.sign_request(:post, '/sapi/v1/margin/order/oco', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/margin/order/oco', timestamp, params: kwargs.merge(
           symbol: symbol,
           side: side,
           quantity: quantity,
@@ -394,6 +410,7 @@ module Binance
       #
       # Canceling an individual leg will cancel the entire OCO
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :isIsolated
@@ -402,10 +419,10 @@ module Binance
       # @option kwargs [String] :newClientOrderId
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-cancel-oco-trade
-      def margin_cancel_oco(symbol:, **kwargs)
+      def margin_cancel_oco(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:delete, '/sapi/v1/margin/orderList', params: kwargs.merge(
+        @session.sign_request(:delete, '/sapi/v1/margin/orderList', timestamp, params: kwargs.merge(
           symbol: symbol
         ))
       end
@@ -414,6 +431,7 @@ module Binance
       #
       # GET /sapi/v1/margin/orderList
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :symbol
       # @option kwargs [String] :isIsolated
@@ -421,14 +439,15 @@ module Binance
       # @option kwargs [String] :origClientOrderId Either orderListId or origClientOrderId must be provided
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-oco-user_data
-      def margin_get_oco(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/orderList', params: kwargs)
+      def margin_get_oco(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/orderList', timestamp, params: kwargs)
       end
 
       # Query Margin Account's all OCO (USER_DATA)
       #
       # GET /sapi/v1/margin/allOrderList
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :symbol
       # @option kwargs [String] :isIsolated
@@ -438,27 +457,29 @@ module Binance
       # @option kwargs [Integer] :limit
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-all-oco-user_data
-      def margin_get_all_oco(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/allOrderList', params: kwargs)
+      def margin_get_all_oco(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/allOrderList', timestamp, params: kwargs)
       end
 
       # Query Margin Account's Open OCO (USER_DATA)
       #
       # GET /sapi/v1/margin/openOrderList
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :symbol
       # @option kwargs [String] :isIsolated
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-open-oco-user_data
-      def margin_get_open_oco(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/openOrderList', params: kwargs)
+      def margin_get_open_oco(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/openOrderList', timestamp, params: kwargs)
       end
 
       # Query Margin Account's Trade List (USER_DATA)
       #
       # GET /sapi/v1/margin/myTrades
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :startTime
@@ -467,46 +488,49 @@ module Binance
       # @option kwargs [Integer] :limit Default 500; max 1000.
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-trade-list-user_data
-      def margin_my_trades(symbol:, **kwargs)
+      def margin_my_trades(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:get, '/sapi/v1/margin/myTrades', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:get, '/sapi/v1/margin/myTrades', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Query Max Borrow (USER_DATA)
       #
       # GET /sapi/v1/margin/maxBorrowable
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :isolatedSymbol
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-max-borrow-user_data
-      def margin_max_borrowable(asset:, **kwargs)
+      def margin_max_borrowable(timestamp = present_timestamp, asset:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
 
-        @session.sign_request(:get, '/sapi/v1/margin/maxBorrowable', params: kwargs.merge(asset: asset))
+        @session.sign_request(:get, '/sapi/v1/margin/maxBorrowable', timestamp, params: kwargs.merge(asset: asset))
       end
 
       # Query Max Transfer-Out Amount (USER_DATA)
       #
       # GET /sapi/v1/margin/maxTransferable
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :isolatedSymbol
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-max-transfer-out-amount-user_data
-      def margin_max_transferable(asset:, **kwargs)
+      def margin_max_transferable(timestamp = present_timestamp, asset:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
 
-        @session.sign_request(:get, '/sapi/v1/margin/maxTransferable', params: kwargs.merge(asset: asset))
+        @session.sign_request(:get, '/sapi/v1/margin/maxTransferable', timestamp, params: kwargs.merge(asset: asset))
       end
 
       # Isolated Margin Account Transfer (MARGIN)
       #
       # POST /sapi/v1/margin/isolated/transfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param symbol [String]
       # @param transFrom [String] "SPOT", "ISOLATED_MARGIN"
@@ -515,14 +539,14 @@ module Binance
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#isolated-margin-account-transfer-margin
-      def isolated_margin_transfer(asset:, symbol:, transFrom:, transTo:, amount:, **kwargs)
+      def isolated_margin_transfer(timestamp = present_timestamp, asset:, symbol:, transFrom:, transTo:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('symbol', symbol)
         Binance::Utils::Validation.require_param('transFrom', transFrom)
         Binance::Utils::Validation.require_param('transTo', transTo)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/margin/isolated/transfer', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/margin/isolated/transfer', timestamp, params: kwargs.merge(
           asset: asset,
           symbol: symbol,
           transFrom: transFrom,
@@ -535,6 +559,7 @@ module Binance
       #
       # GET /sapi/v1/margin/isolated/transfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
@@ -546,86 +571,92 @@ module Binance
       # @option kwargs [Integer] :size Default 10, max 100
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-isolated-margin-transfer-history-user_data
-      def get_isolated_margin_transfer(symbol:, **kwargs)
+      def get_isolated_margin_transfer(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:get, '/sapi/v1/margin/isolated/transfer', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:get, '/sapi/v1/margin/isolated/transfer', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Query Isolated Margin Account Info (USER_DATA)
       #
       # GET /sapi/v1/margin/isolated/account
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :symbols Max 5 symbols can be sent; separated by ",". e.g. "BTCUSDT,BNBUSDT,ADAUSDT"
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-isolated-margin-account-info-user_data
-      def get_isolated_margin_account(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/isolated/account', params: kwargs)
+      def get_isolated_margin_account(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/isolated/account', timestamp, params: kwargs)
       end
 
       # Disable Isolated Margin Account (TRADE)
       #
       # DELETE /sapi/v1/margin/isolated/account
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#disable-isolated-margin-account-trade
-      def disable_isolated_margin_account(symbol:, **kwargs)
+      def disable_isolated_margin_account(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:delete, '/sapi/v1/margin/isolated/account', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:delete, '/sapi/v1/margin/isolated/account', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Enable Isolated Margin Account (TRADE)
       #
       # POST /sapi/v1/margin/isolated/account
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#enable-isolated-margin-account-trade
-      def enable_isolated_margin_account(symbol:, **kwargs)
+      def enable_isolated_margin_account(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:post, '/sapi/v1/margin/isolated/account', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:post, '/sapi/v1/margin/isolated/account', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Query Enabled Isolated Margin Account Limit (USER_DATA)
       #
       # GET /sapi/v1/margin/isolated/accountLimit
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-enabled-isolated-margin-account-limit-user_data
-      def get_isolated_margin_account_limit(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/isolated/accountLimit', params: kwargs)
+      def get_isolated_margin_account_limit(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/isolated/accountLimit', timestamp, params: kwargs)
       end
 
       # Query Isolated Margin Symbol (USER_DATA)
       #
       # GET /sapi/v1/margin/isolated/pair
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-isolated-margin-symbol-user_data
-      def get_isolated_margin_pair(symbol:, **kwargs)
+      def get_isolated_margin_pair(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:get, '/sapi/v1/margin/isolated/pair', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:get, '/sapi/v1/margin/isolated/pair', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Get All Isolated Margin Symbol(USER_DATA)
       #
       # GET /sapi/v1/margin/isolated/allPairs
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-all-isolated-margin-symbol-user_data
-      def get_all_isolated_margin_pairs(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/margin/isolated/allPairs', params: kwargs)
+      def get_all_isolated_margin_pairs(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/isolated/allPairs', timestamp, params: kwargs)
       end
 
       # Toggle BNB Burn On Spot Trade And Margin Interest (USER_DATA)
@@ -634,30 +665,33 @@ module Binance
       #
       # "spotBNBBurn" and "interestBNBBurn" should be sent at least one.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :spotBNBBurn "true" or "false"; Determines whether to use BNB to pay for trading fees on SPOT
       # @option kwargs [String] :interestBNBBurn "true" or "false"; Determines whether to use BNB to pay for margin loan's interest
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#toggle-bnb-burn-on-spot-trade-and-margin-interest-user_data
-      def toggle_bnb_burn(**kwargs)
-        @session.sign_request(:post, '/sapi/v1/bnbBurn', params: kwargs)
+      def toggle_bnb_burn(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:post, '/sapi/v1/bnbBurn', timestamp, params: kwargs)
       end
 
       # Get BNB Burn Status (USER_DATA)
       #
       # GET /sapi/v1/bnbBurn
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-bnb-burn-status-user_data
-      def get_bnb_burn(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/bnbBurn', params: kwargs)
+      def get_bnb_burn(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/bnbBurn', timestamp, params: kwargs)
       end
 
       # Query Margin Interest Rate History (USER_DATA)
       #
       # GET /sapi/v1/margin/interestRateHistory
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param kwargs [Hash]
       # @option vipLevel [Integer] Default: user's vip level
@@ -666,10 +700,10 @@ module Binance
       # @option limit [Integer] Default: 20. Maximum: 100
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-interest-rate-history-user_data
-      def get_margin_interest_rate_history(asset:, **kwargs)
+      def get_margin_interest_rate_history(timestamp = present_timestamp, asset:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
 
-        @session.sign_request(:get, '/sapi/v1/margin/interestRateHistory', params: kwargs.merge(asset: asset))
+        @session.sign_request(:get, '/sapi/v1/margin/interestRateHistory', timestamp, params: kwargs.merge(asset: asset))
       end
     end
   end

--- a/lib/binance/spot/mining.rb
+++ b/lib/binance/spot/mining.rb
@@ -28,18 +28,19 @@ module Binance
       #
       # GET /sapi/v1/mining/worker/detail
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param algo [String]
       # @param userName [String]
       # @param workerName [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#request-for-detail-miner-list-user_data
-      def mining_worker(algo:, userName:, workerName:, **kwargs)
+      def mining_worker(timestamp = present_timestamp, algo:, userName:, workerName:, **kwargs)
         Binance::Utils::Validation.require_param('algo', algo)
         Binance::Utils::Validation.require_param('userName', userName)
         Binance::Utils::Validation.require_param('workerName', workerName)
 
-        @session.sign_request(:get, '/sapi/v1/mining/worker/detail', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/mining/worker/detail', timestamp, params: kwargs.merge(
           algo: algo,
           userName: userName,
           workerName: workerName
@@ -50,6 +51,7 @@ module Binance
       #
       # GET /sapi/v1/mining/worker/list
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param algo [String]
       # @param userName [String]
       # @param kwargs [Hash]
@@ -59,11 +61,11 @@ module Binance
       # @option kwargs [String] :workerStatus
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#request-for-miner-list-user_data
-      def mining_worker_list(algo:, userName:, **kwargs)
+      def mining_worker_list(timestamp = present_timestamp, algo:, userName:, **kwargs)
         Binance::Utils::Validation.require_param('algo', algo)
         Binance::Utils::Validation.require_param('userName', userName)
 
-        @session.sign_request(:get, '/sapi/v1/mining/worker/list', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/mining/worker/list', timestamp, params: kwargs.merge(
           algo: algo,
           userName: userName
         ))
@@ -73,6 +75,7 @@ module Binance
       #
       # GET /sapi/v1/mining/payment/list
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param algo [String]
       # @param userName [String]
       # @param kwargs [Hash]
@@ -83,11 +86,11 @@ module Binance
       # @option kwargs [Integer] :pageSize
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#earnings-list-user_data
-      def mining_revenue_list(algo:, userName:, **kwargs)
+      def mining_revenue_list(timestamp = present_timestamp, algo:, userName:, **kwargs)
         Binance::Utils::Validation.require_param('algo', algo)
         Binance::Utils::Validation.require_param('userName', userName)
 
-        @session.sign_request(:get, '/sapi/v1/mining/payment/list', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/mining/payment/list', timestamp, params: kwargs.merge(
           algo: algo,
           userName: userName
         ))
@@ -97,16 +100,17 @@ module Binance
       #
       # GET /sapi/v1/mining/statistics/user/status
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param algo [String]
       # @param userName [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#statistic-list-user_data
-      def mining_statistics_list(algo:, userName:, **kwargs)
+      def mining_statistics_list(timestamp = present_timestamp, algo:, userName:, **kwargs)
         Binance::Utils::Validation.require_param('algo', algo)
         Binance::Utils::Validation.require_param('userName', userName)
 
-        @session.sign_request(:get, '/sapi/v1/mining/statistics/user/status', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/mining/statistics/user/status', timestamp, params: kwargs.merge(
           algo: algo,
           userName: userName
         ))
@@ -116,16 +120,17 @@ module Binance
       #
       # GET /sapi/v1/mining/statistics/user/list
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param algo [String]
       # @param userName [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#account-list-user_data
-      def mining_account_list(algo:, userName:, **kwargs)
+      def mining_account_list(timestamp = present_timestamp, algo:, userName:, **kwargs)
         Binance::Utils::Validation.require_param('algo', algo)
         Binance::Utils::Validation.require_param('userName', userName)
 
-        @session.sign_request(:get, '/sapi/v1/mining/statistics/user/list', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/mining/statistics/user/list', timestamp, params: kwargs.merge(
           algo: algo,
           userName: userName
         ))
@@ -135,6 +140,7 @@ module Binance
       #
       # GET /sapi/v1/mining/payment/other
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param algo [String]
       # @param userName [String]
       # @param kwargs [Hash]
@@ -145,11 +151,11 @@ module Binance
       # @option kwargs [Integer] :pageSize Number of pages, minimum 10, maximum 200
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#extra-bonus-list-user_data
-      def mining_extra_bonus(algo:, userName:, **kwargs)
+      def mining_extra_bonus(timestamp = present_timestamp, algo:, userName:, **kwargs)
         Binance::Utils::Validation.require_param('algo', algo)
         Binance::Utils::Validation.require_param('userName', userName)
 
-        @session.sign_request(:get, '/sapi/v1/mining/payment/other', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/mining/payment/other', timestamp, params: kwargs.merge(
           algo: algo,
           userName: userName
         ))
@@ -159,19 +165,21 @@ module Binance
       #
       # GET /sapi/v1/mining/hash-transfer/config/details/list
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :pageIndex Page number, empty default first page, starting from 1
       # @option kwargs [Integer] :pageSize Number of pages, minimum 10, maximum 200
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#hashrate-resale-list-user_data
-      def mining_resale_list(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/mining/hash-transfer/config/details/list', params: kwargs)
+      def mining_resale_list(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/mining/hash-transfer/config/details/list', timestamp, params: kwargs)
       end
 
       # Hashrate Resale Detail (USER_DATA)
       #
       # GET /sapi/v1/mining/hash-transfer/profit/details
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param configId [String] Mining ID
       # @param userName [String] Mining Account
       # @param kwargs [Hash]
@@ -179,11 +187,11 @@ module Binance
       # @option kwargs [Integer] :pageSize Number of pages, minimum 10, maximum 200
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#hashrate-resale-detail-user_data
-      def mining_resale_detail(configId:, userName:, **kwargs)
+      def mining_resale_detail(timestamp = present_timestamp, configId:, userName:, **kwargs)
         Binance::Utils::Validation.require_param('configId', configId)
         Binance::Utils::Validation.require_param('userName', userName)
 
-        @session.sign_request(:get, '/sapi/v1/mining/hash-transfer/profit/details', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/mining/hash-transfer/profit/details', timestamp, params: kwargs.merge(
           configId: configId,
           userName: userName
         ))
@@ -193,6 +201,7 @@ module Binance
       #
       # POST /sapi/v1/mining/hash-transfer/config
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param userName [String] Mining Account
       # @param algo [String] Transfer algorithm(sha256)
       # @param startDate [Integer] Resale End Time (Millisecond timestamp)
@@ -202,7 +211,7 @@ module Binance
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#hashrate-resale-request-user_data
-      def mining_resale_request(userName:, algo:, startDate:, endDate:, toPoolUser:, hashRate:, **kwargs)
+      def mining_resale_request(timestamp = present_timestamp, userName:, algo:, startDate:, endDate:, toPoolUser:, hashRate:, **kwargs)
         Binance::Utils::Validation.require_param('userName', userName)
         Binance::Utils::Validation.require_param('algo', algo)
         Binance::Utils::Validation.require_param('startDate', startDate)
@@ -210,7 +219,7 @@ module Binance
         Binance::Utils::Validation.require_param('toPoolUser', toPoolUser)
         Binance::Utils::Validation.require_param('hashRate', hashRate)
 
-        @session.sign_request(:post, '/sapi/v1/mining/hash-transfer/config', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/mining/hash-transfer/config', timestamp, params: kwargs.merge(
           userName: userName,
           algo: algo,
           startDate: startDate,
@@ -224,16 +233,17 @@ module Binance
       #
       # POST /sapi/v1/mining/hash-transfer/config/cancel
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param configId [String] Mining ID
       # @param userName [String] Mining Account
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cancel-hashrate-resale-configuration-user_data
-      def mining_resale_cancel(configId:, userName:, **kwargs)
+      def mining_resale_cancel(timestamp = present_timestamp, configId:, userName:, **kwargs)
         Binance::Utils::Validation.require_param('userName', userName)
         Binance::Utils::Validation.require_param('configId', configId)
 
-        @session.sign_request(:post, '/sapi/v1/mining/hash-transfer/config/cancel', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/mining/hash-transfer/config/cancel', timestamp, params: kwargs.merge(
           configId: configId,
           userName: userName
         ))

--- a/lib/binance/spot/savings.rb
+++ b/lib/binance/spot/savings.rb
@@ -9,6 +9,7 @@ module Binance
       #
       # GET /sapi/v1/lending/daily/product/list
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :status "ALL", "SUBSCRIBABLE", "UNSUBSCRIBABLE"; Default: "ALL"
       # @option kwargs [String] :featured "ALL", "TRUE"; Default: "ALL"
@@ -16,22 +17,23 @@ module Binance
       # @option kwargs [Integer] :size Default: 50, Max: 100
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-flexible-product-list-user_data
-      def savings_flexible_products(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/lending/daily/product/list', params: kwargs)
+      def savings_flexible_products(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/lending/daily/product/list', timestamp, params: kwargs)
       end
 
       # Get Left Daily Purchase Quota of Flexible Product (USER_DATA)
       #
       # GET /sapi/v1/lending/daily/userLeftQuota
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param productId [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-left-daily-purchase-quota-of-flexible-product-user_data
-      def savings_flexible_user_left_quota(productId:, **kwargs)
+      def savings_flexible_user_left_quota(timestamp = present_timestamp, productId:, **kwargs)
         Binance::Utils::Validation.require_param('productId', productId)
 
-        @session.sign_request(:get, '/sapi/v1/lending/daily/userLeftQuota', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/lending/daily/userLeftQuota', timestamp, params: kwargs.merge(
           productId: productId
         ))
       end
@@ -40,16 +42,17 @@ module Binance
       #
       # POST /sapi/v1/lending/daily/purchase
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param productId [String]
       # @param amount [Float]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#purchase-flexible-product-user_data
-      def savings_purchase_flexible_product(productId:, amount:, **kwargs)
+      def savings_purchase_flexible_product(timestamp = present_timestamp, productId:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('productId', productId)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/lending/daily/purchase', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/lending/daily/purchase', timestamp, params: kwargs.merge(
           productId: productId,
           amount: amount
         ))
@@ -59,16 +62,17 @@ module Binance
       #
       # GET /sapi/v1/lending/daily/userRedemptionQuota
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param productId [String]
       # @param type [String] "FAST", "NORMAL"
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-left-daily-redemption-quota-of-flexible-product-user_data
-      def savings_flexible_user_redemption_quota(productId:, type:, **kwargs)
+      def savings_flexible_user_redemption_quota(timestamp = present_timestamp, productId:, type:, **kwargs)
         Binance::Utils::Validation.require_param('productId', productId)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:get, '/sapi/v1/lending/daily/userRedemptionQuota', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/lending/daily/userRedemptionQuota', timestamp, params: kwargs.merge(
           productId: productId,
           type: type
         ))
@@ -78,18 +82,19 @@ module Binance
       #
       # POST /sapi/v1/lending/daily/redeem
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param productId [String]
       # @param amount [Float]]
       # @param type [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#redeem-flexible-product-user_data
-      def savings_flexible_redeem(productId:, amount:, type:, **kwargs)
+      def savings_flexible_redeem(timestamp = present_timestamp, productId:, amount:, type:, **kwargs)
         Binance::Utils::Validation.require_param('productId', productId)
         Binance::Utils::Validation.require_param('amount', amount)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:post, '/sapi/v1/lending/daily/redeem', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/lending/daily/redeem', timestamp, params: kwargs.merge(
           productId: productId,
           amount: amount,
           type: type
@@ -100,14 +105,15 @@ module Binance
       #
       # GET /sapi/v1/lending/daily/token/position
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-flexible-product-position-user_data
-      def savings_flexible_product_position(asset:, **kwargs)
+      def savings_flexible_product_position(timestamp = present_timestamp, asset:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
 
-        @session.sign_request(:get, '/sapi/v1/lending/daily/token/position', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/lending/daily/token/position', timestamp, params: kwargs.merge(
           asset: asset
         ))
       end
@@ -116,6 +122,7 @@ module Binance
       #
       # GET /sapi/v1/lending/project/list
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param type [String] "REGULAR", "CUSTOMIZED_FIXED"
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
@@ -126,10 +133,10 @@ module Binance
       # @option kwargs [Integer] :size Default:10, Max:100
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-fixed-and-activity-project-list-user_data
-      def savings_product_list(type:, **kwargs)
+      def savings_product_list(timestamp = present_timestamp, type:, **kwargs)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:get, '/sapi/v1/lending/project/list', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/lending/project/list', timestamp, params: kwargs.merge(
           type: type
         ))
       end
@@ -138,16 +145,17 @@ module Binance
       #
       # POST /sapi/v1/lending/customizedFixed/purchase
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param projectId [String]
       # @param lot [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#purchase-fixed-activity-project-user_data
-      def savings_purchase_customized_project(projectId:, lot:, **kwargs)
+      def savings_purchase_customized_project(timestamp = present_timestamp, projectId:, lot:, **kwargs)
         Binance::Utils::Validation.require_param('projectId', projectId)
         Binance::Utils::Validation.require_param('lot', lot)
 
-        @session.sign_request(:post, '/sapi/v1/lending/customizedFixed/purchase', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/lending/customizedFixed/purchase', timestamp, params: kwargs.merge(
           projectId: projectId,
           lot: lot
         ))
@@ -157,16 +165,17 @@ module Binance
       #
       # GET /sapi/v1/lending/project/position/list
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :projectId
       # @option kwargs [String] :status "HOLDING", "REDEEMED"
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-fixed-activity-project-position-user_data
-      def savings_customized_position(asset:, **kwargs)
+      def savings_customized_position(timestamp = present_timestamp, asset:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
 
-        @session.sign_request(:get, '/sapi/v1/lending/project/position/list', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/lending/project/position/list', timestamp, params: kwargs.merge(
           asset: asset
         ))
       end
@@ -175,17 +184,19 @@ module Binance
       #
       # GET /sapi/v1/lending/union/account
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#lending-account-user_data
-      def savings_account(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/lending/union/account', params: kwargs)
+      def savings_account(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/lending/union/account', timestamp, params: kwargs)
       end
 
       # Get Purchase Record (USER_DATA)
       #
       # GET /sapi/v1/lending/union/purchaseRecord
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param lendingType [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
@@ -195,10 +206,10 @@ module Binance
       # @option kwargs [Integer] :size
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-purchase-record-user_data
-      def savings_purchase_record(lendingType:, **kwargs)
+      def savings_purchase_record(timestamp = present_timestamp, lendingType:, **kwargs)
         Binance::Utils::Validation.require_param('lendingType', lendingType)
 
-        @session.sign_request(:get, '/sapi/v1/lending/union/purchaseRecord', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/lending/union/purchaseRecord', timestamp, params: kwargs.merge(
           lendingType: lendingType
         ))
       end
@@ -207,6 +218,7 @@ module Binance
       #
       # GET /sapi/v1/lending/union/redemptionRecord
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param lendingType [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
@@ -216,10 +228,10 @@ module Binance
       # @option kwargs [Integer] :size
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-redemption-record-user_data
-      def savings_redemption_record(lendingType:, **kwargs)
+      def savings_redemption_record(timestamp = present_timestamp, lendingType:, **kwargs)
         Binance::Utils::Validation.require_param('lendingType', lendingType)
 
-        @session.sign_request(:get, '/sapi/v1/lending/union/redemptionRecord', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/lending/union/redemptionRecord', timestamp, params: kwargs.merge(
           lendingType: lendingType
         ))
       end
@@ -228,6 +240,7 @@ module Binance
       #
       # GET /sapi/v1/lending/union/interestHistory
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param lendingType [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
@@ -237,10 +250,10 @@ module Binance
       # @option kwargs [Integer] :size
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-interest-history-user_data-2
-      def savings_interest_history(lendingType:, **kwargs)
+      def savings_interest_history(timestamp = present_timestamp, lendingType:, **kwargs)
         Binance::Utils::Validation.require_param('lendingType', lendingType)
 
-        @session.sign_request(:get, '/sapi/v1/lending/union/interestHistory', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/lending/union/interestHistory', timestamp, params: kwargs.merge(
           lendingType: lendingType
         ))
       end
@@ -249,17 +262,18 @@ module Binance
       #
       # POST /sapi/v1/lending/positionChanged
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param projectId [String]
       # @param lot [Integer]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :positionId
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#change-fixed-activity-position-to-daily-position-user_data
-      def savings_position_changed(projectId:, lot:, **kwargs)
+      def savings_position_changed(timestamp = present_timestamp, projectId:, lot:, **kwargs)
         Binance::Utils::Validation.require_param('projectId', projectId)
         Binance::Utils::Validation.require_param('lot', lot)
 
-        @session.sign_request(:post, '/sapi/v1/lending/positionChanged', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/lending/positionChanged', timestamp, params: kwargs.merge(
           projectId: projectId,
           lot: lot
         ))

--- a/lib/binance/spot/subaccount.rb
+++ b/lib/binance/spot/subaccount.rb
@@ -12,14 +12,15 @@ module Binance
       # This request will generate a virtual sub account under your master account.<br>
       # You need to enable "trade" option for the api key which requests this endpoint.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param subAccountString [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#create-a-virtual-sub-account-for-master-account
-      def create_virtual_sub_account(subAccountString:, **kwargs)
+      def create_virtual_sub_account(timestamp = present_timestamp, subAccountString:, **kwargs)
         Binance::Utils::Validation.require_param('subAccountString', subAccountString)
 
-        @session.sign_request(:post, '/sapi/v1/sub-account/virtualSubAccount', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/sub-account/virtualSubAccount', timestamp, params: kwargs.merge(
           subAccountString: subAccountString
         ))
       end
@@ -28,6 +29,7 @@ module Binance
       #
       # GET /sapi/v1/sub-account/list
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :email Sub-account email
       # @option kwargs [String] :isFreeze true or false
@@ -35,8 +37,8 @@ module Binance
       # @option kwargs [Integer] :limit
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-sub-account-list-for-master-account
-      def get_sub_account_list(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/sub-account/list', params: kwargs)
+      def get_sub_account_list(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/sub-account/list', timestamp, params: kwargs)
       end
 
       # Query Sub-account Spot Asset Transfer History (For Master Account)
@@ -46,6 +48,7 @@ module Binance
       # fromEmail and toEmail cannot be sent at the same time.<br>
       # Return fromEmail equal master account email by default.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :fromEmail Sub-account email
       # @option kwargs [String] :toEmail Sub-account email
@@ -55,14 +58,15 @@ module Binance
       # @option kwargs [Integer] :limit Default value: 500
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-sub-account-spot-asset-transfer-history-for-master-account
-      def get_sub_account_spot_transfer_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/sub-account/sub/transfer/history', params: kwargs)
+      def get_sub_account_spot_transfer_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/sub-account/sub/transfer/history', timestamp, params: kwargs)
       end
 
       # Query Sub-account Futures Asset Transfer History (For Master Account)
       #
       # GET /sapi/v1/sub-account/futures/internalTransfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param futuresType [Integer] 1:USDT-margined Futures, 2: Coin-margined Futures
       # @param kwargs [Hash]
@@ -72,11 +76,11 @@ module Binance
       # @option kwargs [Integer] :limit Default value: 50, Max value: 500
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-sub-account-futures-asset-transfer-history-for-master-account
-      def get_sub_account_futures_transfer_history(email:, futuresType:, **kwargs)
+      def get_sub_account_futures_transfer_history(timestamp = present_timestamp, email:, futuresType:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
         Binance::Utils::Validation.require_param('futuresType', futuresType)
 
-        @session.sign_request(:get, '/sapi/v1/sub-account/futures/internalTransfer', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/sub-account/futures/internalTransfer', timestamp, params: kwargs.merge(
           email: email,
           futuresType: futuresType
         ))
@@ -86,6 +90,7 @@ module Binance
       #
       # POST /sapi/v1/sub-account/futures/internalTransfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param fromEmail [String]
       # @param toEmail [String]
       # @param futuresType [Integer] 1:USDT-margined Futures, 2: Coin-margined Futures
@@ -94,14 +99,14 @@ module Binance
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#sub-account-futures-asset-transfer-for-master-account
-      def sub_account_futures_internal_transfer(fromEmail:, toEmail:, futuresType:, asset:, amount:, **kwargs)
+      def sub_account_futures_internal_transfer(timestamp = present_timestamp, fromEmail:, toEmail:, futuresType:, asset:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('fromEmail', fromEmail)
         Binance::Utils::Validation.require_param('toEmail', toEmail)
         Binance::Utils::Validation.require_param('futuresType', futuresType)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/sub-account/futures/internalTransfer', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/sub-account/futures/internalTransfer', timestamp, params: kwargs.merge(
           fromEmail: fromEmail,
           toEmail: toEmail,
           futuresType: futuresType,
@@ -114,14 +119,15 @@ module Binance
       #
       # GET /sapi/v3/sub-account/assets
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-sub-account-assets-for-master-account
-      def get_sub_account_assets(email:, **kwargs)
+      def get_sub_account_assets(timestamp = present_timestamp, email:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
 
-        @session.sign_request(:get, '/sapi/v3/sub-account/assets', params: kwargs.merge(email: email))
+        @session.sign_request(:get, '/sapi/v3/sub-account/assets', timestamp, params: kwargs.merge(email: email))
       end
 
       # Query Sub-account Spot Assets Summary (For Master Account)
@@ -130,14 +136,15 @@ module Binance
       #
       # Get BTC valued asset summary of subaccounts.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :email
       # @option kwargs [Integer] :page Default value: 1
       # @option kwargs [Integer] :size default 10, max 20
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-sub-account-spot-assets-summary-for-master-account
-      def get_sub_account_spot_summary(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/sub-account/spotSummary', params: kwargs)
+      def get_sub_account_spot_summary(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/sub-account/spotSummary', timestamp, params: kwargs)
       end
 
       # Get Sub-account Deposit Address (For Master Account)
@@ -146,17 +153,18 @@ module Binance
       #
       # Fetch sub-account deposit address
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param coin [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :network
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-sub-account-deposit-address-for-master-account
-      def sub_account_deposit_address(email:, coin:, **kwargs)
+      def sub_account_deposit_address(timestamp = present_timestamp, email:, coin:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
         Binance::Utils::Validation.require_param('coin', coin)
 
-        @session.sign_request(:get, '/sapi/v1/capital/deposit/subAddress', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/capital/deposit/subAddress', timestamp, params: kwargs.merge(
           email: email,
           coin: coin
         ))
@@ -168,6 +176,7 @@ module Binance
       #
       # Fetch sub-account deposit history
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :coin
@@ -178,10 +187,10 @@ module Binance
       # @option kwargs [String] :offset
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-sub-account-deposit-history-for-master-account
-      def sub_account_deposit_history(email:, **kwargs)
+      def sub_account_deposit_history(timestamp = present_timestamp, email:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
 
-        @session.sign_request(:get, '/sapi/v1/capital/deposit/subHisrec', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/capital/deposit/subHisrec', timestamp, params: kwargs.merge(
           email: email
         ))
       end
@@ -190,26 +199,28 @@ module Binance
       #
       # GET /sapi/v1/sub-account/status
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :email
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-sub-account-39-s-status-on-margin-futures-for-master-account
-      def sub_account_status(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/sub-account/status', params: kwargs)
+      def sub_account_status(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/sub-account/status', timestamp, params: kwargs)
       end
 
       # Enable Margin for Sub-account (For Master Account)
       #
       # POST /sapi/v1/sub-account/margin/enable
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :email
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-sub-account-39-s-status-on-margin-futures-for-master-account
-      def sub_account_enable_margin(email:, **kwargs)
+      def sub_account_enable_margin(timestamp = present_timestamp, email:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
 
-        @session.sign_request(:post, '/sapi/v1/sub-account/margin/enable', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/sub-account/margin/enable', timestamp, params: kwargs.merge(
           email: email
         ))
       end
@@ -218,14 +229,15 @@ module Binance
       #
       # GET /sapi/v1/sub-account/margin/account
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-detail-on-sub-account-39-s-margin-account-for-master-account
-      def sub_account_margin_account(email:, **kwargs)
+      def sub_account_margin_account(timestamp = present_timestamp, email:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
 
-        @session.sign_request(:get, '/sapi/v1/sub-account/margin/account', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/sub-account/margin/account', timestamp, params: kwargs.merge(
           email: email
         ))
       end
@@ -234,25 +246,27 @@ module Binance
       #
       # GET /sapi/v1/sub-account/margin/accountSummary
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-summary-of-sub-account-39-s-margin-account-for-master-account
-      def sub_account_margin_account_summary(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/sub-account/margin/accountSummary', params: kwargs)
+      def sub_account_margin_account_summary(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/sub-account/margin/accountSummary', timestamp, params: kwargs)
       end
 
       # Enable Futures for Sub-account (For Master Account)
       #
       # POST /sapi/v1/sub-account/futures/enable
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#enable-futures-for-sub-account-for-master-account
-      def sub_account_enable_futures(email:, **kwargs)
+      def sub_account_enable_futures(timestamp = present_timestamp, email:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
 
-        @session.sign_request(:post, '/sapi/v1/sub-account/futures/enable', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/sub-account/futures/enable', timestamp, params: kwargs.merge(
           email: email
         ))
       end
@@ -261,16 +275,17 @@ module Binance
       #
       # GET /sapi/v2/sub-account/futures/account
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param futuresType [Integer] 1:USDT Margined Futures, 2:COIN Margined Futures
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-detail-on-sub-account-39-s-futures-account-v2-for-master-account
-      def sub_account_futures_account(email:, futuresType:, **kwargs)
+      def sub_account_futures_account(timestamp = present_timestamp, email:, futuresType:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
         Binance::Utils::Validation.require_param('futuresType', futuresType)
 
-        @session.sign_request(:get, '/sapi/v2/sub-account/futures/account', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v2/sub-account/futures/account', timestamp, params: kwargs.merge(
           email: email,
           futuresType: futuresType
         ))
@@ -280,16 +295,17 @@ module Binance
       #
       # GET /sapi/v2/sub-account/futures/accountSummary
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param futuresType [Integer] 1:USDT Margined Futures, 2:COIN Margined Futures
       # @param kwargs [Hash]
       # @option kwargs [Integer] :page  default:1
       # @option kwargs [Integer] :limit default:10, max:20
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-summary-of-sub-account-39-s-futures-account-v2-for-master-account
-      def sub_account_futures_account_summary(futuresType:, **kwargs)
+      def sub_account_futures_account_summary(timestamp = present_timestamp, futuresType:, **kwargs)
         Binance::Utils::Validation.require_param('futuresType', futuresType)
 
-        @session.sign_request(:get, '/sapi/v2/sub-account/futures/accountSummary', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v2/sub-account/futures/accountSummary', timestamp, params: kwargs.merge(
           futuresType: futuresType
         ))
       end
@@ -298,16 +314,17 @@ module Binance
       #
       # GET /sapi/v2/sub-account/futures/positionRisk
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param futuresType [Integer] 1:USDT Margined Futures, 2:COIN Margined Futures
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-futures-position-risk-of-sub-account-v2-for-master-account
-      def sub_account_futures_position_risk(email:, futuresType:, **kwargs)
+      def sub_account_futures_position_risk(timestamp = present_timestamp, email:, futuresType:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
         Binance::Utils::Validation.require_param('futuresType', futuresType)
 
-        @session.sign_request(:get, '/sapi/v2/sub-account/futures/positionRisk', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v2/sub-account/futures/positionRisk', timestamp, params: kwargs.merge(
           email: email,
           futuresType: futuresType
         ))
@@ -317,6 +334,7 @@ module Binance
       #
       # POST /sapi/v1/sub-account/futures/transfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param asset [String]
       # @param amount [Float]
@@ -327,13 +345,13 @@ module Binance
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#futures-transfer-for-sub-account-for-master-account
-      def sub_account_futures_transfer(email:, asset:, amount:, type:, **kwargs)
+      def sub_account_futures_transfer(timestamp = present_timestamp, email:, asset:, amount:, type:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:post, '/sapi/v1/sub-account/futures/transfer', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/sub-account/futures/transfer', timestamp, params: kwargs.merge(
           email: email,
           asset: asset,
           amount: amount,
@@ -345,6 +363,7 @@ module Binance
       #
       # POST /sapi/v1/sub-account/margin/transfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param asset [String]
       # @param amount [Float]
@@ -353,13 +372,13 @@ module Binance
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#margin-transfer-for-sub-account-for-master-account
-      def sub_account_margin_transfer(email:, asset:, amount:, type:, **kwargs)
+      def sub_account_margin_transfer(timestamp = present_timestamp, email:, asset:, amount:, type:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:post, '/sapi/v1/sub-account/margin/transfer', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/sub-account/margin/transfer', timestamp, params: kwargs.merge(
           email: email,
           asset: asset,
           amount: amount,
@@ -371,18 +390,19 @@ module Binance
       #
       # POST /sapi/v1/sub-account/transfer/subToSub
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param toEmail [String]
       # @param asset [String]
       # @param amount [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#transfer-to-sub-account-of-same-master-for-sub-account
-      def sub_account_transfer_to_sub(toEmail:, asset:, amount:, **kwargs)
+      def sub_account_transfer_to_sub(timestamp = present_timestamp, toEmail:, asset:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('toEmail', toEmail)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/sub-account/transfer/subToSub', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/sub-account/transfer/subToSub', timestamp, params: kwargs.merge(
           toEmail: toEmail,
           asset: asset,
           amount: amount
@@ -393,16 +413,17 @@ module Binance
       #
       # POST /sapi/v1/sub-account/transfer/subToMaster
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [String]
       # @param amount [Float]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#transfer-to-master-for-sub-account
-      def sub_account_transfer_to_master(asset:, amount:, **kwargs)
+      def sub_account_transfer_to_master(timestamp = present_timestamp, asset:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/sub-account/transfer/subToMaster', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/sub-account/transfer/subToMaster', timestamp, params: kwargs.merge(
           asset: asset,
           amount: amount
         ))
@@ -412,6 +433,7 @@ module Binance
       #
       # GET /sapi/v1/sub-account/transfer/subUserHistory
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
       # @option kwargs [Integer] :type 1: transfer in, 2: transfer out
@@ -420,8 +442,8 @@ module Binance
       # @option kwargs [Integer] :limit
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#sub-account-transfer-history-for-sub-account
-      def sub_account_transfer_sub_account_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/sub-account/transfer/subUserHistory', params: kwargs)
+      def sub_account_transfer_sub_account_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/sub-account/transfer/subUserHistory', timestamp, params: kwargs)
       end
 
       # Universal Transfer (For Master Account)
@@ -431,6 +453,7 @@ module Binance
       # You need to enable "internal transfer" option for the api key which requests this endpoint.<br>
       # Transfer between futures accounts is not supported.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param fromAccountType [String] "SPOT","USDT_FUTURE","COIN_FUTURE"
       # @param toAccountType [String] "SPOT","USDT_FUTURE","COIN_FUTURE"
       # @param asset [String]
@@ -440,13 +463,13 @@ module Binance
       # @option kwargs [String] :toEmail Transfer to master account by default if toEmail is not sent.
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#universal-transfer-for-master-account
-      def universal_transfer(fromAccountType:, toAccountType:, asset:, amount:, **kwargs)
+      def universal_transfer(timestamp = present_timestamp, fromAccountType:, toAccountType:, asset:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('fromAccountType', fromAccountType)
         Binance::Utils::Validation.require_param('toAccountType', toAccountType)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/sub-account/universalTransfer', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/sub-account/universalTransfer', timestamp, params: kwargs.merge(
           fromAccountType: fromAccountType,
           toAccountType: toAccountType,
           asset: asset,
@@ -458,6 +481,7 @@ module Binance
       #
       # GET /sapi/v1/sub-account/universalTransfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :fromEmail
       # @option kwargs [String] :toEmail
@@ -467,24 +491,25 @@ module Binance
       # @option kwargs [Integer] :limit Default 500, Max 500
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-universal-transfer-history-for-master-account
-      def universal_transfer_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/sub-account/universalTransfer', params: kwargs)
+      def universal_transfer_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/sub-account/universalTransfer', timestamp, params: kwargs)
       end
 
       # Enable Leverage Token for Sub-account (For Master Account)
       #
       # POST /sapi/v1/sub-account/blvt/enable
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param enableBlvt [Boolean] Only true for now
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#enable-leverage-token-for-sub-account-for-master-account
-      def sub_account_enable_blvt(email:, enableBlvt:, **kwargs)
+      def sub_account_enable_blvt(timestamp = present_timestamp, email:, enableBlvt:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
         Binance::Utils::Validation.require_param('enableBlvt', enableBlvt)
 
-        @session.sign_request(:post, '/sapi/v1/sub-account/blvt/enable', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/sub-account/blvt/enable', timestamp, params: kwargs.merge(
           email: email,
           enableBlvt: enableBlvt
         ))
@@ -494,18 +519,19 @@ module Binance
       #
       # POST /sapi/v1/managed-subaccount/deposit
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param toEmail [String]
       # @param asset [String]
       # @param amount [Float]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#deposit-assets-into-the-managed-sub-account-for-investor-master-account
-      def deposit_to_sub_account(toEmail:, asset:, amount:, **kwargs)
+      def deposit_to_sub_account(timestamp = present_timestamp, toEmail:, asset:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('toEmail', toEmail)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/managed-subaccount/deposit', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/managed-subaccount/deposit', timestamp, params: kwargs.merge(
           toEmail: toEmail,
           asset: asset,
           amount: amount
@@ -516,20 +542,22 @@ module Binance
       #
       # GET /sapi/v1/managed-subaccount/asset
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param email [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-managed-sub-account-asset-details-for-investor-master-account
-      def sub_account_asset_details(email:, **kwargs)
+      def sub_account_asset_details(timestamp = present_timestamp, email:, **kwargs)
         Binance::Utils::Validation.require_param('email', email)
 
-        @session.sign_request(:get, '/sapi/v1/managed-subaccount/asset', params: kwargs.merge(email: email))
+        @session.sign_request(:get, '/sapi/v1/managed-subaccount/asset', timestamp, params: kwargs.merge(email: email))
       end
 
       # Withdrawl assets from the managed sub-account (For Investor Master Account)
       #
       # POST /sapi/v1/managed-subaccount/withdraw
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param fromEmail  [String]
       # @param asset [String]
       # @param amount [Float]
@@ -537,12 +565,12 @@ module Binance
       # @option kwargs [Integer] :transferDate
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#withdrawl-assets-from-the-managed-sub-account-for-investor-master-account
-      def withdraw_from_sub_account(fromEmail:, asset:, amount:, **kwargs)
+      def withdraw_from_sub_account(timestamp = present_timestamp, fromEmail:, asset:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('fromEmail', fromEmail)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/managed-subaccount/withdraw', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/managed-subaccount/withdraw', timestamp, params: kwargs.merge(
           fromEmail: fromEmail,
           asset: asset,
           amount: amount

--- a/lib/binance/spot/trade.rb
+++ b/lib/binance/spot/trade.rb
@@ -16,6 +16,7 @@ module Binance
       #
       # send in a new order to test the request, no order is really generated.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String] the symbol
       # @param side [String]
       # @param type [String]
@@ -30,12 +31,12 @@ module Binance
       # @option kwargs [String] :newOrderRespType Set the response JSON. ACK, RESULT, or FULL.
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#test-new-order-trade
-      def new_order_test(symbol:, side:, type:, **kwargs)
+      def new_order_test(timestamp = present_timestamp, symbol:, side:, type:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
         Binance::Utils::Validation.require_param('side', side)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:post, '/api/v3/order/test', params: kwargs.merge(
+        @session.sign_request(:post, '/api/v3/order/test', timestamp, params: kwargs.merge(
           symbol: symbol,
           side: side,
           type: type
@@ -48,6 +49,7 @@ module Binance
       #
       # send in a new order
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String] the symbol
       # @param side [String]
       # @param type [String]
@@ -62,12 +64,12 @@ module Binance
       # @option kwargs [String] :newOrderRespType Set the response JSON. ACK, RESULT, or FULL.
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#new-order-trade
-      def new_order(symbol:, side:, type:, **kwargs)
+      def new_order(timestamp = present_timestamp, symbol:, side:, type:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
         Binance::Utils::Validation.require_param('side', side)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:post, '/api/v3/order', params: kwargs.merge(
+        @session.sign_request(:post, '/api/v3/order', timestamp, params: kwargs.merge(
           symbol: symbol,
           side: side,
           type: type
@@ -78,6 +80,7 @@ module Binance
       #
       # DELETE /api/v3/order
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String] the symbol
       # @param kwargs [Hash]
       # @option kwargs [Integer] :orderId
@@ -85,52 +88,55 @@ module Binance
       # @option kwargs [String] :newClientOrderId
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cancel-order-trade
-      def cancel_order(symbol:, **kwargs)
+      def cancel_order(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:delete, '/api/v3/order', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:delete, '/api/v3/order', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Cancel all Open Orders on a Symbol (TRADE)
       #
       # DELETE /api/v3/openOrders
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String] the symbol
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cancel-all-open-orders-on-a-symbol-trade
-      def cancel_open_orders(symbol:, **kwargs)
+      def cancel_open_orders(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:delete, '/api/v3/openOrders', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:delete, '/api/v3/openOrders', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Query Order (USER_DATA)
       #
       # GET /api/v3/order
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String] the symbol
       # @param kwargs [Hash]
       # @option kwargs [Integer] :orderId
       # @option kwargs [String] :origClientOrderId
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-order-user_data
-      def get_order(symbol:, **kwargs)
+      def get_order(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:get, '/api/v3/order', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:get, '/api/v3/order', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Current Open Orders (USER_DATA)
       #
       # GET /api/v3/openOrders
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :symbol the symbol
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#current-open-orders-user_data
-      def open_orders(**kwargs)
-        @session.sign_request(:get, '/api/v3/openOrders', params: kwargs)
+      def open_orders(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/api/v3/openOrders', timestamp, params: kwargs)
       end
 
       # All Orders (USER_DATA)
@@ -139,6 +145,7 @@ module Binance
       #
       # Get all account orders; active, canceled, or filled.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String] the symbol
       # @param kwargs [Hash]
       # @option kwargs [String] :orderId
@@ -147,10 +154,10 @@ module Binance
       # @option kwargs [String] :limit Default 500; max 1000.
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#all-orders-user_data
-      def all_orders(symbol:, **kwargs)
+      def all_orders(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:get, '/api/v3/allOrders', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:get, '/api/v3/allOrders', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # New OCO (TRADE)
@@ -159,6 +166,7 @@ module Binance
       #
       # Send in a new OCO
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String] the symbol
       # @param side [String]
       # @param quantity [Float]
@@ -175,14 +183,14 @@ module Binance
       # @option kwargs [String] :newOrderRespType
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#new-oco-trade
-      def new_oco_order(symbol:, side:, quantity:, price:, stopPrice:, **kwargs)
+      def new_oco_order(timestamp = present_timestamp, symbol:, side:, quantity:, price:, stopPrice:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
         Binance::Utils::Validation.require_param('side', side)
         Binance::Utils::Validation.require_param('quantity', quantity)
         Binance::Utils::Validation.require_param('price', price)
         Binance::Utils::Validation.require_param('stopPrice', stopPrice)
 
-        @session.sign_request(:post, '/api/v3/order/oco', params: kwargs.merge(
+        @session.sign_request(:post, '/api/v3/order/oco', timestamp, params: kwargs.merge(
           symbol: symbol,
           side: side,
           quantity: quantity,
@@ -195,6 +203,7 @@ module Binance
       #
       # DELETE /api/v3/orderList
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String] the symbol
       # @param kwargs [Hash]
       # @option kwargs [Integer] :orderListId
@@ -202,10 +211,10 @@ module Binance
       # @option kwargs [String] :newClientOrderId
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#cancel-oco-trade
-      def cancel_order_list(symbol:, **kwargs)
+      def cancel_order_list(timestamp = present_timestamp, symbol:, **kwargs)
         Binance::Utils::Validation.require_param('symbol', symbol)
 
-        @session.sign_request(:delete, '/api/v3/orderList', params: kwargs.merge(symbol: symbol))
+        @session.sign_request(:delete, '/api/v3/orderList', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Query OCO (USER_DATA)
@@ -214,13 +223,14 @@ module Binance
       #
       # Retrieves a specific OCO based on provided optional parameters
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :orderListId
       # @option kwargs [String] :orgClientOrderId
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-oco-user_data
-      def order_list(**kwargs)
-        @session.sign_request(:get, '/api/v3/orderList', params: kwargs)
+      def order_list(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/api/v3/orderList', timestamp, params: kwargs)
       end
 
       # Query all OCO (USER_DATA)
@@ -229,6 +239,7 @@ module Binance
       #
       # Retrieves all OCO based on provided optional parameters
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :fromId
       # @option kwargs [String] :startTime
@@ -236,36 +247,39 @@ module Binance
       # @option kwargs [String] :limit Default 500; max 1000.
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-all-oco-user_data
-      def all_order_list(**kwargs)
-        @session.sign_request(:get, '/api/v3/allOrderList', params: kwargs)
+      def all_order_list(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/api/v3/allOrderList', timestamp, params: kwargs)
       end
 
       # Query Open OCO (USER_DATA)
       #
       # GET /api/v3/openOrderList
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-open-oco-user_data
-      def open_order_list(**kwargs)
-        @session.sign_request(:get, '/api/v3/openOrderList', params: kwargs)
+      def open_order_list(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/api/v3/openOrderList', timestamp, params: kwargs)
       end
 
       # Account Information (USER_DATA)
       #
       # GET /api/v3/account
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#account-information-user_data
-      def account(**kwargs)
-        @session.sign_request(:get, '/api/v3/account', params: kwargs)
+      def account(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/api/v3/account', timestamp, params: kwargs)
       end
 
       # Account Trade List (USER_DATA)
       #
       # GET /api/v3/myTrades
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param symbol [String] the symbol
       # @param kwargs [Hash]
       # @option kwargs [Integer] :orderId
@@ -275,19 +289,20 @@ module Binance
       # @option kwargs [Integer] :limit Default 500; max 1000.
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#account-trade-list-user_data
-      def my_trades(symbol:, **kwargs)
-        @session.sign_request(:get, '/api/v3/myTrades', params: kwargs.merge(symbol: symbol))
+      def my_trades(timestamp = present_timestamp, symbol:, **kwargs)
+        @session.sign_request(:get, '/api/v3/myTrades', timestamp, params: kwargs.merge(symbol: symbol))
       end
 
       # Query Current Order Count Usage (TRADE)
       #
       # GET /api/v3/rateLimit/order
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-current-order-count-usage-trade
-      def get_order_rate_limit(**kwargs)
-        @session.sign_request(:get, '/api/v3/rateLimit/order', params: kwargs)
+      def get_order_rate_limit(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/api/v3/rateLimit/order', timestamp, params: kwargs)
       end
     end
   end

--- a/lib/binance/spot/wallet.rb
+++ b/lib/binance/spot/wallet.rb
@@ -22,17 +22,19 @@ module Binance
       #
       # Get information of coins (available for deposit and withdraw) for user.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#all-coins-39-information-user_data
-      def coin_info(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/capital/config/getall', params: kwargs)
+      def coin_info(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/capital/config/getall', timestamp, params: kwargs)
       end
 
       # Daily Account Snapshot (USER_DATA)
       #
       # GET /sapi/v1/accountSnapshot
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param type [String] "SPOT", "MARGIN", "FUTURES"
       # @param kwargs [Hash]
       # @option kwargs [Integer] :startTime
@@ -40,10 +42,10 @@ module Binance
       # @option kwargs [Integer] :limit min 5, max 30, default 5
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#daily-account-snapshot-user_data
-      def account_snapshot(type:, **kwargs)
+      def account_snapshot(timestamp = present_timestamp, type:, **kwargs)
         Binance::Utils::Validation.require_param('type', type)
 
-        @session.sign_request(:get, '/sapi/v1/accountSnapshot', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/accountSnapshot', timestamp, params: kwargs.merge(
           type: type
         ))
       end
@@ -52,28 +54,31 @@ module Binance
       #
       # POST /sapi/v1/account/disableFastWithdrawSwitch
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#disable-fast-withdraw-switch-user_data
-      def disable_fast_withdraw(**kwargs)
-        @session.sign_request(:post, '/sapi/v1/account/disableFastWithdrawSwitch', params: kwargs)
+      def disable_fast_withdraw(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:post, '/sapi/v1/account/disableFastWithdrawSwitch', timestamp, params: kwargs)
       end
 
       # Enable Fast Withdraw Switch (USER_DATA)
       #
       # POST /sapi/v1/account/enableFastWithdrawSwitch
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#enable-fast-withdraw-switch-user_data
-      def enable_fast_withdraw(**kwargs)
-        @session.sign_request(:post, '/sapi/v1/account/enableFastWithdrawSwitch', params: kwargs)
+      def enable_fast_withdraw(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:post, '/sapi/v1/account/enableFastWithdrawSwitch', timestamp, params: kwargs)
       end
 
       # Withdraw [SAPI]
       #
       # POST /sapi/v1/capital/withdraw/apply
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param coin [String]
       # @param address [String]
       # @param amount [Float]
@@ -85,12 +90,12 @@ module Binance
       # @option kwargs [String] :name
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#withdraw-sapi
-      def withdraw(coin:, address:, amount:, **kwargs)
+      def withdraw(timestamp = present_timestamp, coin:, address:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('coin', coin)
         Binance::Utils::Validation.require_param('address', address)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/capital/withdraw/apply', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/capital/withdraw/apply', timestamp, params: kwargs.merge(
           coin: coin,
           address: address,
           amount: amount
@@ -101,6 +106,7 @@ module Binance
       #
       # GET /sapi/v1/capital/deposit/hisrec
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :coin
       # @option kwargs [Integer] :status 0(0:pending,6: credited but cannot withdraw, 1:success)
@@ -110,14 +116,15 @@ module Binance
       # @option kwargs [Integer] :limit Default:1000, Max:1000
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#deposit-history-supporting-network-user_data
-      def deposit_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/capital/deposit/hisrec', params: kwargs)
+      def deposit_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/capital/deposit/hisrec', timestamp, params: kwargs)
       end
 
       # Withdraw History (supporting network) (USER_DATA)
       #
       # GET /sapi/v1/capital/withdraw/history
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :coin
       # @option kwargs [String] :withdrawOrderId
@@ -128,23 +135,24 @@ module Binance
       # @option kwargs [Integer] :limit
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#withdraw-history-supporting-network-user_data
-      def withdraw_history(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/capital/withdraw/history', params: kwargs)
+      def withdraw_history(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/capital/withdraw/history', timestamp, params: kwargs)
       end
 
       # Deposit Address (supporting network) (USER_DATA)
       #
       # GET /sapi/v1/capital/deposit/address
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param coin [String]
       # @param kwargs [Hash]
       # @option kwargs [String] :network
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#withdraw-history-supporting-network-user_data
-      def deposit_address(coin:, **kwargs)
+      def deposit_address(timestamp = present_timestamp, coin:, **kwargs)
         Binance::Utils::Validation.require_param('coin', coin)
 
-        @session.sign_request(:get, '/sapi/v1/capital/deposit/address', params: kwargs.merge(
+        @session.sign_request(:get, '/sapi/v1/capital/deposit/address', timestamp, params: kwargs.merge(
           coin: coin
         ))
       end
@@ -155,11 +163,12 @@ module Binance
       #
       # Fetch account status detail.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#account-status-user_data
-      def account_status(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/account/status', params: kwargs)
+      def account_status(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/account/status', timestamp, params: kwargs)
       end
 
       # Account API Trading Status (USER_DATA)
@@ -168,24 +177,26 @@ module Binance
       #
       # Fetch account api trading status detail.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#account-api-trading-status-user_data
-      def api_trading_status(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/account/apiTradingStatus', params: kwargs)
+      def api_trading_status(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/account/apiTradingStatus', timestamp, params: kwargs)
       end
 
       # DustLog (USER_DATA)
       #
       # GET /sapi/v1/asset/dribblet
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :startTime
       # @option kwargs [Integer] :endTime
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#dustlog-user_data
-      def dust_log(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/asset/dribblet', params: kwargs)
+      def dust_log(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/asset/dribblet', timestamp, params: kwargs)
       end
 
       # Dust Transfer (USER_DATA)
@@ -194,14 +205,15 @@ module Binance
       #
       # Convert dust assets to BNB.
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param asset [Array]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#dust-transfer-user_data
-      def dust_transfer(asset:, **kwargs)
+      def dust_transfer(timestamp = present_timestamp, asset:, **kwargs)
         Binance::Utils::Validation.require_param('asset', asset)
 
-        @session.sign_request(:post, '/sapi/v1/asset/dust', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/asset/dust', timestamp, params: kwargs.merge(
           asset: asset
         ))
       end
@@ -210,6 +222,7 @@ module Binance
       #
       # GET /sapi/v1/asset/assetDividend
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
       # @option kwargs [Integer] :startTime
@@ -217,38 +230,41 @@ module Binance
       # @option kwargs [Integer] :limit Default 20, max 500
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#asset-dividend-record-user_data
-      def asset_devidend_record(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/asset/assetDividend', params: kwargs)
+      def asset_devidend_record(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/asset/assetDividend', timestamp, params: kwargs)
       end
 
       # Asset Detail (USER_DATA)
       #
       # GET /sapi/v1/asset/assetDetail
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#asset-detail-user_data
-      def asset_detail(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/asset/assetDetail', params: kwargs)
+      def asset_detail(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/asset/assetDetail', timestamp, params: kwargs)
       end
 
       # Trade Fee (USER_DATA)
       #
       # GET /sapi/v1/asset/tradeFee
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :symbol
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#trade-fee-user_data
-      def trade_fee(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/asset/tradeFee', params: kwargs)
+      def trade_fee(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/asset/tradeFee', timestamp, params: kwargs)
       end
 
       # User Universal Transfer (USER_DATA)
       #
       # POST /sapi/v1/asset/transfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param type [String]
       # @param asset [String]
       # @param amount [Float]
@@ -257,12 +273,12 @@ module Binance
       # @option kwargs [String] :toSymbol must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#user-universal-transfer-user_data
-      def user_universal_transfer(type:, asset:, amount:, **kwargs)
+      def user_universal_transfer(timestamp = present_timestamp, type:, asset:, amount:, **kwargs)
         Binance::Utils::Validation.require_param('type', type)
         Binance::Utils::Validation.require_param('asset', asset)
         Binance::Utils::Validation.require_param('amount', amount)
 
-        @session.sign_request(:post, '/sapi/v1/asset/transfer', params: kwargs.merge(
+        @session.sign_request(:post, '/sapi/v1/asset/transfer', timestamp, params: kwargs.merge(
           type: type,
           asset: asset,
           amount: amount
@@ -273,6 +289,7 @@ module Binance
       #
       # GET /sapi/v1/asset/transfer
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param type [String]
       # @param kwargs [Hash]
       # @option kwargs [Integer] :startTime
@@ -283,33 +300,35 @@ module Binance
       # @option kwargs [String] :toSymbol must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#query-user-universal-transfer-history-user_data
-      def user_universal_transfer_history(type:, **kwargs)
+      def user_universal_transfer_history(timestamp = present_timestamp, type:, **kwargs)
         Binance::Utils::Validation.require_param('type', type)
-        @session.sign_request(:get, '/sapi/v1/asset/transfer', params: kwargs.merge(type: type))
+        @session.sign_request(:get, '/sapi/v1/asset/transfer', timestamp, params: kwargs.merge(type: type))
       end
 
       # Funding Wallet (USER_DATA)
       #
       # POST /sapi/v1/asset/get-funding-asset
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [String] :asset
       # @option kwargs [String] :needBtcValuation true or false
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#funding-wallet-user_data
-      def funding_wallet(**kwargs)
-        @session.sign_request(:post, '/sapi/v1/asset/get-funding-asset', params: kwargs)
+      def funding_wallet(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:post, '/sapi/v1/asset/get-funding-asset', timestamp, params: kwargs)
       end
 
       # Get API Key Permission (USER_DATA)
       #
       # GET /sapi/v1/account/apiRestrictions
       #
+      # @param timestamp [String] Number of milliseconds since 1970-01-01 00:00:00 UTC
       # @param kwargs [Hash]
       # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
       # @see https://binance-docs.github.io/apidocs/spot/en/#get-api-key-permission-user_data
-      def api_key_permission(**kwargs)
-        @session.sign_request(:get, '/sapi/v1/account/apiRestrictions', params: kwargs)
+      def api_key_permission(timestamp = present_timestamp, **kwargs)
+        @session.sign_request(:get, '/sapi/v1/account/apiRestrictions', timestamp, params: kwargs)
       end
     end
   end

--- a/lib/binance/utils/faraday/middleware/timestamp.rb
+++ b/lib/binance/utils/faraday/middleware/timestamp.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
-require 'date'
-
 module Binance
   module Utils
     module Faraday
       module Middleware
-        Timestamp = Struct.new(:app) do
+        Timestamp = Struct.new(:app, :timestamp) do
           def call(env)
             env.url.query = Url.add_param(
-              env.url.query, 'timestamp', DateTime.now.strftime('%Q')
+              env.url.query, 'timestamp', timestamp
             )
             app.call env
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,11 @@ def stub_send_binance_request(verb, path)
   stub_request(verb, "https://api.binance.com#{path}")
 end
 
+def mocking_signature(params = {})
+  allow(OpenSSL::Digest).to receive(:new).and_return('')
+  allow(OpenSSL::HMAC).to receive(:hexdigest).with('', FAKE_SECRET, build_query(**params)).and_return(FAKE_SIGNATURE)
+end
+
 def mocking_signature_and_ts(params = {})
   allow(OpenSSL::Digest).to receive(:new).and_return('')
   allow(OpenSSL::HMAC).to receive(:hexdigest).with('', FAKE_SECRET, build_query(**params)).and_return(FAKE_SIGNATURE)


### PR DESCRIPTION
Hello,

Here is a proposal to define a present timestamp that could be different from the one of the host system executing the code. This would allow to execute valid requests even when the local clock is not correctly configured.

The default behavior remains the use of the system time in the absence of an explicitly given `timestamp` parameter.