### PR TITLE
Add service to get convert trade history

### DIFF
--- a/lib/binance/spot.rb
+++ b/lib/binance/spot.rb
@@ -8,6 +8,7 @@ require 'binance/error'
 require 'binance/spot/blvt'
 require 'binance/spot/bswap'
 require 'binance/spot/c2c'
+require 'binance/spot/convert'
 require 'binance/spot/fiat'
 require 'binance/spot/futures'
 require 'binance/spot/loan'
@@ -26,6 +27,7 @@ module Binance
   # - Blvt
   # - Bswap
   # - C2C
+  # - Convert
   # - Fiat
   # - Futures
   # - Loan
@@ -42,6 +44,7 @@ module Binance
     include Binance::Spot::Blvt
     include Binance::Spot::Bswap
     include Binance::Spot::C2C
+    include Binance::Spot::Convert
     include Binance::Spot::Fiat
     include Binance::Spot::Futures
     include Binance::Spot::Loan

--- a/lib/binance/spot/convert.rb
+++ b/lib/binance/spot/convert.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Binance
+  class Spot
+    # Convert endpoints
+    # @see https://binance-docs.github.io/apidocs/spot/en/#convert-endpoints
+    module Convert
+      # Get Convert Trade History (USER_DATA)
+      #
+      # GET /sapi/v1/convert/tradeFlow
+      #
+      # @param startTime [Integer]
+      # @param endTime [Integer]
+      # @param kwargs [Hash]
+      # @option kwargs [Integer] :limit default 100, max 1000
+      # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
+      # @see https://binance-docs.github.io/apidocs/spot/en/#convert-endpoints
+      def convert_trade_flow(startTime:, endTime:, **kwargs)
+        Binance::Utils::Validation.require_param('startTime', startTime)
+        Binance::Utils::Validation.require_param('endTime', endTime)
+
+        @session.sign_request(:get, '/sapi/v1/convert/tradeFlow', params: kwargs.merge(
+          startTime: startTime,
+          endTime: endTime
+        ))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a method for the [Get Convert Trade History](https://binance-docs.github.io/apidocs/spot/en/#convert-endpoints) service

Implemented this for myself, figured I might as well share it =)