### PR TITLE
v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.2.0 - 2022-07-15
+
+### Add
+- Sub account endpoints
+  - `POST /sapi/v1/sub-account/subAccountApi/ipRestriction` to support master account enable and disable IP restriction for a sub-account API Key
+  - `POST /sapi/v1/sub-account/subAccountApi/ipRestriction/ipList` to support master account add IP list for a sub-account API Key
+  - `GET /sapi/v1/account/apiRestrictions/ipRestriction` to support master account query IP restriction for a sub-account API Key
+  - `DELETE /sapi/v1/account/apiRestrictions/ipRestriction/ipList` to support master account delete IP list for a sub-account API Key
+- Market endpoint
+  - `GET /api/v3/ticker`
+- Trade endpoint
+  - `POST /api/v3/order/cancelReplace`
+- Websocket methods
+  - `<symbol>@ticker_<window_size>`
+  - `!ticker_<window-size>@arr`
+
+
 ## 1.1.0 - 2022-06-09
 
 ### Add

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    binance-connector-ruby (1.0.3)
+    binance-connector-ruby (1.1.0)
       faraday (~> 1.8)
       websocket-eventmachine-client (~> 1.3)
 

--- a/examples/spot/market/ticker.rb
+++ b/examples/spot/market/ticker.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift('./lib')
+
+require 'binance'
+require_relative '../../common'
+
+logger = Common.setup_logger
+
+client = Binance::Spot.new
+
+# single symbol
+# logger.info(client.ticker(symbol: 'btcusdt', windowSize: '1d'))
+
+# multi symbols
+logger.info(client.ticker(symbols: %w[btcusdt btcbusd], windowSize: '1d'))

--- a/examples/spot/subaccount/sub_account_add_ip_list.rb
+++ b/examples/spot/subaccount/sub_account_add_ip_list.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift('./lib')
+
+require 'binance'
+require_relative '../../common'
+
+logger = Common.setup_logger
+
+client = Binance::Spot.new(key: '', secret: '')
+logger.info(client.sub_account_add_ip_list(email: 'alice@test.com', subAccountApiKey: 'xxxxxx', ipAddress: '1.2.3.4'))

--- a/examples/spot/subaccount/sub_account_delete_ip_list.rb
+++ b/examples/spot/subaccount/sub_account_delete_ip_list.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift('./lib')
+
+require 'binance'
+require_relative '../../common'
+
+logger = Common.setup_logger
+
+client = Binance::Spot.new(key: '', secret: '')
+logger.info(client.sub_account_delete_ip_list(email: 'alice@test.com', subAccountApiKey: 'xxxxxx', ipAddress: '1.2.3.4'))

--- a/examples/spot/subaccount/sub_account_ip_list.rb
+++ b/examples/spot/subaccount/sub_account_ip_list.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift('./lib')
+
+require 'binance'
+require_relative '../../common'
+
+logger = Common.setup_logger
+
+client = Binance::Spot.new(key: '', secret: '')
+logger.info(client.sub_account_ip_list(email: 'alice@test.com', subAccountApiKey: 'xxxxxx'))

--- a/examples/spot/subaccount/sub_account_toggle_ip_restriction.rb
+++ b/examples/spot/subaccount/sub_account_toggle_ip_restriction.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift('./lib')
+
+require 'binance'
+require_relative '../../common'
+
+logger = Common.setup_logger
+
+client = Binance::Spot.new(key: '', secret: '')
+logger.info(client.sub_account_toggle_ip_restriction(email: 'alice@test.com', subAccountApiKey: 'xxxxxx', ipRestrict: true))

--- a/examples/spot/trade/cancel_replace.rb
+++ b/examples/spot/trade/cancel_replace.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift('./lib')
+
+require 'binance'
+require_relative '../../common'
+
+logger = Common.setup_logger
+
+# set key and secret here
+# or BINANCE_PUBLIC_API_KEY and BINANCE_PRIVATE_SECRET in env
+
+key = ''
+secret = ''
+client = Binance::Spot.new(key: key, secret: secret, base_url: 'https://testnet.binance.vision')
+
+params = {
+  symbol: 'BNBUSDT',
+  side: 'BUY',
+  type: 'LIMIT',
+  cancelReplaceMode: 'STOP_ON_FAILURE',
+  timeInForce: 'GTC',
+  quantity: 1,
+  price: 200,
+  cancelOrderId: 1_234_567, # this should be a real existing open order id.
+  newOrderRespType: 'FULL'
+}
+
+logger.info(client.cancel_replace(**params))

--- a/examples/websocket/spot/rolling_window_ticker.rb
+++ b/examples/websocket/spot/rolling_window_ticker.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift('./lib')
+
+require 'binance'
+require 'eventmachine'
+require_relative '../../common'
+
+logger = Common.setup_logger
+
+client = Binance::Spot::WebSocket.new
+
+EM.run do
+  onopen = proc { logger.info('connected to server') }
+  onmessage = proc { |msg, _type| logger.info(msg) }
+  onerror   = proc { |e| logger.error(e) }
+  onclose   = proc { logger.info('connection closed') }
+
+  callbacks = {
+    onopen: onopen,
+    onmessage: onmessage,
+    onerror: onerror,
+    onclose: onclose
+  }
+
+  client.rolling_window_ticker(symbol: 'btcusdt', windowSize: '1h', callbacks: callbacks)
+end

--- a/examples/websocket/spot/rolling_window_ticker_all_symbols.rb
+++ b/examples/websocket/spot/rolling_window_ticker_all_symbols.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift('./lib')
+
+require 'binance'
+require 'eventmachine'
+require_relative '../../common'
+
+logger = Common.setup_logger
+
+client = Binance::Spot::WebSocket.new
+
+EM.run do
+  onopen = proc { logger.info('connected to server') }
+  onmessage = proc { |msg, _type| logger.info(msg) }
+  onerror   = proc { |e| logger.error(e) }
+  onclose   = proc { logger.info('connection closed') }
+
+  callbacks = {
+    onopen: onopen,
+    onmessage: onmessage,
+    onerror: onerror,
+    onclose: onclose
+  }
+
+  client.rolling_window_ticker_all_symbols(windowSize: '1h', callbacks: callbacks)
+end

--- a/lib/binance/error.rb
+++ b/lib/binance/error.rb
@@ -25,4 +25,11 @@ module Binance
       )
     end
   end
+
+  # Error when Multi parameters are not allowed to send together
+  class DuplicatedParametersError < Error
+    def initialize(*kwargs)
+      super("Parameters #{kwargs} should not be sent to server together.")
+    end
+  end
 end

--- a/lib/binance/spot/market.rb
+++ b/lib/binance/spot/market.rb
@@ -215,6 +215,32 @@ module Binance
           params: { symbol: symbol }
         )
       end
+
+      # Symbol Order Book Ticker
+      #
+      # Best price/qty on the order book for a symbol or symbols.
+      #
+      # GET /api/v3/ticker/bookTicker
+      #
+      # @param symbol [String] the symbol
+      # @see https://binance-docs.github.io/apidocs/spot/en/#symbol-order-book-ticker
+      def ticker(symbol: nil, symbols: nil, windowSize: '1d')
+        raise Binance::DuplicatedParametersError.new('symbol', 'symbols') unless symbols.nil? || symbol.nil?
+
+        params = { symbol: symbol.upcase } if symbol
+
+        if symbols
+          symbols = symbols.map { |s| "\"#{s}\"" }.join(',')
+          params = { symbols: "\[#{symbols}\]".upcase }
+        end
+
+        params[:windowSize] = windowSize
+
+        @session.public_request(
+          path: '/api/v3/ticker',
+          params: params
+        )
+      end
     end
   end
 end

--- a/lib/binance/spot/subaccount.rb
+++ b/lib/binance/spot/subaccount.rb
@@ -548,6 +548,87 @@ module Binance
           amount: amount
         ))
       end
+
+      # Enable or Disable IP Restriction for a Sub-account API Key (For Master Account)
+      #
+      # POST /sapi/v1/sub-account/subAccountApi/ipRestriction
+      #
+      # @param email  [String]
+      # @param subAccountApiKey [String]
+      # @param ipRestrict [Boolean]
+      # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
+      # @see https://binance-docs.github.io/apidocs/spot/en/#enable-or-disable-ip-restriction-for-a-sub-account-api-key-for-master-account
+      def sub_account_toggle_ip_restriction(email:, subAccountApiKey:, ipRestrict:, **kwargs)
+        Binance::Utils::Validation.require_param('email', email)
+        Binance::Utils::Validation.require_param('subAccountApiKey', subAccountApiKey)
+        Binance::Utils::Validation.require_param('ipRestrict', ipRestrict)
+
+        @session.sign_request(:post, '/sapi/v1/sub-account/subAccountApi/ipRestriction', params: kwargs.merge(
+          email: email,
+          subAccountApiKey: subAccountApiKey,
+          ipRestrict: ipRestrict
+        ))
+      end
+
+      # Add IP List for a Sub-account API Key (For Master Account)
+      #
+      # POST /sapi/v1/sub-account/subAccountApi/ipRestriction/ipList
+      #
+      # @param email  [String]
+      # @param subAccountApiKey [String]
+      # @param ipAddress [String]
+      # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
+      # @see https://binance-docs.github.io/apidocs/spot/en/#add-ip-list-for-a-sub-account-api-key-for-master-account
+      def sub_account_add_ip_list(email:, subAccountApiKey:, ipAddress:, **kwargs)
+        Binance::Utils::Validation.require_param('email', email)
+        Binance::Utils::Validation.require_param('subAccountApiKey', subAccountApiKey)
+        Binance::Utils::Validation.require_param('ipAddress', ipAddress)
+
+        @session.sign_request(:post, '/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList', params: kwargs.merge(
+          email: email,
+          subAccountApiKey: subAccountApiKey,
+          ipAddress: ipAddress
+        ))
+      end
+
+      # Get IP Restriction for a Sub-account API Key (For Master Account)
+      #
+      # GET /sapi/v1/sub-account/subAccountApi/ipRestriction
+      #
+      # @param email  [String]
+      # @param subAccountApiKey [String]
+      # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
+      # @see https://binance-docs.github.io/apidocs/spot/en/#get-ip-restriction-for-a-sub-account-api-key-for-master-account
+      def sub_account_ip_list(email:, subAccountApiKey:, **kwargs)
+        Binance::Utils::Validation.require_param('email', email)
+        Binance::Utils::Validation.require_param('subAccountApiKey', subAccountApiKey)
+
+        @session.sign_request(:get, '/sapi/v1/sub-account/subAccountApi/ipRestriction', params: kwargs.merge(
+          email: email,
+          subAccountApiKey: subAccountApiKey
+        ))
+      end
+
+      # Delete IP List For a Sub-account API Key (For Master Account)
+      #
+      # DELETE /sapi/v1/sub-account/subAccountApi/ipRestriction/ipList
+      #
+      # @param email  [String]
+      # @param subAccountApiKey [String]
+      # @param ipAddress [String]
+      # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
+      # @see https://binance-docs.github.io/apidocs/spot/en/#get-ip-restriction-for-a-sub-account-api-key-for-master-account
+      def sub_account_delete_ip_list(email:, subAccountApiKey:, ipAddress:, **kwargs)
+        Binance::Utils::Validation.require_param('email', email)
+        Binance::Utils::Validation.require_param('subAccountApiKey', subAccountApiKey)
+        Binance::Utils::Validation.require_param('ipAddress', ipAddress)
+
+        @session.sign_request(:delete, '/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList', params: kwargs.merge(
+          email: email,
+          subAccountApiKey: subAccountApiKey,
+          ipAddress: ipAddress
+        ))
+      end
     end
   end
 end

--- a/lib/binance/spot/trade.rb
+++ b/lib/binance/spot/trade.rb
@@ -289,6 +289,44 @@ module Binance
       def get_order_rate_limit(**kwargs)
         @session.sign_request(:get, '/api/v3/rateLimit/order', params: kwargs)
       end
+
+      # Cancel an Existing Order and Send a New Order (TRADE)
+      #
+      # POST /api/v3/order/cancelReplace
+      #
+      # @param symbol [String] the symbol
+      # @param side [String]
+      # @param type [String]
+      # @param cancelReplaceMode [String] STOP_ON_FAILURE or ALLOW_FAILURE
+      # @param kwargs [Hash]
+      # @option kwargs [String] :timeInForce
+      # @option kwargs [Float] :quantity
+      # @option kwargs [Float] :quoteOrderQty
+      # @option kwargs [Float] :price
+      # @option kwargs [String] :cancelNewClientOrderId
+      # @option kwargs [String] :cancelOrigClientOrderId
+      # @option kwargs [Integer] :cancelOrderId
+      # @option kwargs [String] :newClientOrderId
+      # @option kwargs [Float] :stopPrice
+      # @option kwargs [Integer] :trailingDelta
+      # @option kwargs [Float] :icebergQty
+      # @option kwargs [String] :newOrderRespType
+      # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
+      # @see https://binance-docs.github.io/apidocs/spot/en/#cancel-an-existing-order-and-send-a-new-order-trade
+      def cancel_replace(symbol:, side:, type:, cancelReplaceMode:, **kwargs)
+        Binance::Utils::Validation.require_param('symbol', symbol)
+        Binance::Utils::Validation.require_param('side', side)
+        Binance::Utils::Validation.require_param('type', type)
+        Binance::Utils::Validation.require_param('cancelReplaceMode', cancelReplaceMode)
+
+        @session.sign_request(:post, '/api/v3/order/cancelReplace',
+                              params: kwargs.merge(
+                                symbol: symbol,
+                                side: side,
+                                type: type,
+                                cancelReplaceMode: cancelReplaceMode
+                              ))
+      end
     end
   end
 end

--- a/lib/binance/spot/websocket.rb
+++ b/lib/binance/spot/websocket.rb
@@ -126,6 +126,30 @@ module Binance
         create_connection(url, callbacks)
       end
 
+      # Individual Symbol Rolling Window Statistics Streams
+      # Rolling window ticker statistics for a single symbol, computed over multiple windows.
+      # Stream Name: <symbol>@ticker_<window_size>
+      # Window Sizes: 1h,4h
+      # Update Speed:  1000ms
+      #
+      # @see https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-rolling-window-statistics-streams
+      def rolling_window_ticker(symbol:, windowSize:, callbacks:)
+        url = "#{@base_url}/ws/#{symbol.downcase}@ticker_#{windowSize}"
+        create_connection(url, callbacks)
+      end
+
+      # All Market Rolling Window Statistics Streams
+      # Rolling window ticker statistics for all market symbols, computed over multiple windows. Note that only tickers that have changed will be present in the array.
+      # Stream Name: !ticker_<window-size>@arr
+      # Window Sizes: 1h, 4h
+      # Update Speed:  1000ms
+      #
+      # @see https://binance-docs.github.io/apidocs/spot/en/#all-market-rolling-window-statistics-streams
+      def rolling_window_ticker_all_symbols(windowSize:, callbacks:)
+        url = "#{@base_url}/ws/!ticker_#{windowSize}@arr"
+        create_connection(url, callbacks)
+      end
+
       # Subscribe to a stream manually
       # subscribe(stream: "btcusdt@miniTicker") or
       # subscribe(stream: ["btcusdt@miniTicker", "ethusdt@miniTicker"])

--- a/spec/binance/spot/market/ticker_spec.rb
+++ b/spec/binance/spot/market/ticker_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Binance::Spot::Market, '#ticker' do
+  let(:symbol) { 'BNBUSDT' }
+  let(:body) { fixture('response.json') }
+  let(:status) { 200 }
+
+  before do
+    stub_binance_request(:get, path, status, body)
+  end
+
+  context 'with both symbol and symbols' do
+    let(:path) { '/api/v3/ticker' }
+    it 'should raise error' do
+      expect do
+        spot_client.ticker(symbol: symbol, symbols: %w[BNBBUSD BNBUSDT])
+      end.to raise_error(Binance::DuplicatedParametersError)
+    end
+  end
+
+  context 'with symbol' do
+    let(:path) { "/api/v3/ticker?symbol=#{symbol}&windowSize=1d" }
+    it 'should return one ticker' do
+      spot_client.ticker(symbol: symbol)
+      expect(send_a_request(:get, path)).to have_been_made
+    end
+  end
+
+  context 'with symbols' do
+    let(:path) { '/api/v3/ticker?symbols=["BNBBUSD","BNBUSDT"]&windowSize=1h' }
+    it 'should return 2 symbols\' ticker' do
+      spot_client.ticker(symbols: %w[BNBBUSD BNBUSDT], windowSize: '1h')
+      expect(send_a_request(:get, path)).to have_been_made
+    end
+  end
+end

--- a/spec/binance/spot/subaccount/sub_account_add_ip_list_spec.rb
+++ b/spec/binance/spot/subaccount/sub_account_add_ip_list_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Binance::Spot::Subaccount, '#sub_account_add_ip_list' do
+  let(:path) { '/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList' }
+  let(:body) { fixture('response.json') }
+  let(:status) { 200 }
+  let(:sub_acct_api_key) { 'the_api_key' }
+  let(:email) { 'alice@test.com' }
+  let(:ip) { '1.2.3.4' }
+
+  before do
+    mocking_signature_and_ts(**params)
+    stub_binance_sign_request(:post, path, status, body, params)
+  end
+
+  context 'validation' do
+    where(:params) do
+      [
+        { email: '', subAccountApiKey: sub_acct_api_key, ipAddress: ip },
+        { email: email, subAccountApiKey: '', ipAddress: ip },
+        { email: email, subAccountApiKey: sub_acct_api_key, ipAddress: '' }
+      ]
+    end
+    with_them do
+      it 'should raise validation error without mandatory params' do
+        expect { spot_client_signed.sub_account_add_ip_list(**params) }.to raise_error(Binance::RequiredParameterError)
+      end
+    end
+  end
+
+  context 'with params' do
+    let(:params) { { email: email, subAccountApiKey: sub_acct_api_key, ipAddress: ip } }
+    it 'should add ip list' do
+      spot_client_signed.sub_account_add_ip_list(**params)
+      expect(send_a_request_with_signature(:post, path, params)).to have_been_made
+    end
+  end
+end

--- a/spec/binance/spot/subaccount/sub_account_delete_ip_list_spec.rb
+++ b/spec/binance/spot/subaccount/sub_account_delete_ip_list_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Binance::Spot::Subaccount, '#sub_account_delete_ip_list' do
+  let(:path) { '/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList' }
+  let(:body) { fixture('response.json') }
+  let(:status) { 200 }
+  let(:sub_acct_api_key) { 'the_api_key' }
+  let(:email) { 'alice@test.com' }
+  let(:ip) { '1.2.3.4' }
+
+  before do
+    mocking_signature_and_ts(**params)
+    stub_binance_sign_request(:delete, path, status, body, params)
+  end
+
+  context 'validation' do
+    where(:params) do
+      [
+        { email: '', subAccountApiKey: sub_acct_api_key, ipAddress: ip },
+        { email: email, subAccountApiKey: '', ipAddress: ip },
+        { email: email, subAccountApiKey: sub_acct_api_key, ipAddress: '' }
+      ]
+    end
+    with_them do
+      it 'should raise validation error without mandatory params' do
+        expect { spot_client_signed.sub_account_delete_ip_list(**params) }.to raise_error(Binance::RequiredParameterError)
+      end
+    end
+  end
+
+  context 'with params' do
+    let(:params) { { email: email, subAccountApiKey: sub_acct_api_key, ipAddress: ip } }
+    it 'should add ip list' do
+      spot_client_signed.sub_account_delete_ip_list(**params)
+      expect(send_a_request_with_signature(:delete, path, params)).to have_been_made
+    end
+  end
+end

--- a/spec/binance/spot/subaccount/sub_account_ip_list_spec.rb
+++ b/spec/binance/spot/subaccount/sub_account_ip_list_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Binance::Spot::Subaccount, '#sub_account_ip_list' do
+  let(:path) { '/sapi/v1/sub-account/subAccountApi/ipRestriction' }
+  let(:body) { fixture('response.json') }
+  let(:status) { 200 }
+  let(:sub_acct_api_key) { 'the_api_key' }
+  let(:email) { 'alice@test.com' }
+  let(:ip) { '1.2.3.4' }
+
+  before do
+    mocking_signature_and_ts(**params)
+    stub_binance_sign_request(:get, path, status, body, params)
+  end
+
+  context 'validation' do
+    where(:params) do
+      [
+        { email: '', subAccountApiKey: sub_acct_api_key },
+        { email: email, subAccountApiKey: '' }
+      ]
+    end
+    with_them do
+      it 'should raise validation error without mandatory params' do
+        expect { spot_client_signed.sub_account_ip_list(**params) }.to raise_error(Binance::RequiredParameterError)
+      end
+    end
+  end
+
+  context 'with params' do
+    let(:params) { { email: email, subAccountApiKey: sub_acct_api_key } }
+    it 'should add ip list' do
+      spot_client_signed.sub_account_ip_list(**params)
+      expect(send_a_request_with_signature(:get, path, params)).to have_been_made
+    end
+  end
+end

--- a/spec/binance/spot/subaccount/sub_account_toggle_ip_restriction_spec.rb
+++ b/spec/binance/spot/subaccount/sub_account_toggle_ip_restriction_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Binance::Spot::Subaccount, '#sub_account_toggle_ip_restriction' do
+  let(:path) { '/sapi/v1/sub-account/subAccountApi/ipRestriction' }
+  let(:body) { fixture('response.json') }
+  let(:status) { 200 }
+  let(:sub_acct_api_key) { 'the_api_key' }
+  let(:email) { 'alice@test.com' }
+
+  before do
+    mocking_signature_and_ts(**params)
+    stub_binance_sign_request(:post, path, status, body, params)
+  end
+
+  context 'validation' do
+    where(:params) do
+      [
+        { email: '', subAccountApiKey: sub_acct_api_key, ipRestrict: true },
+        { email: email, subAccountApiKey: '', ipRestrict: true },
+        { email: email, subAccountApiKey: sub_acct_api_key, ipRestrict: '' }
+      ]
+    end
+    with_them do
+      it 'should raise validation error without mandatory params' do
+        expect { spot_client_signed.sub_account_toggle_ip_restriction(**params) }.to raise_error(Binance::RequiredParameterError)
+      end
+    end
+  end
+
+  context 'with params' do
+    let(:params) { { email: email, subAccountApiKey: sub_acct_api_key, ipRestrict: true } }
+    it 'should toggle the ip ipRestriction on sub account' do
+      spot_client_signed.sub_account_toggle_ip_restriction(**params)
+      expect(send_a_request_with_signature(:post, path, params)).to have_been_made
+    end
+  end
+end

--- a/spec/binance/spot/trade/cancel_replace_spec.rb
+++ b/spec/binance/spot/trade/cancel_replace_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Binance::Spot::Trade, '#cancel_replace' do
+  let(:path) { '/api/v3/order/cancelReplace' }
+  let(:body) { fixture('response.json') }
+  let(:status) { 200 }
+  let(:params) do
+    {
+      symbol: 'BNBBUSD',
+      side: 'BUY',
+      type: 'LIMIT',
+      cancelReplaceMode: 'STOP_ON_FAILURE'
+    }
+  end
+
+  before do
+    mocking_signature_and_ts(**params)
+    stub_binance_sign_request(:post, path, status, body, params)
+  end
+
+  context 'validation symbol' do
+    let(:params) { { symbol: '', side: 'BUY', type: 'LIMIT', cancelReplaceMode: 'STOP_ON_FAILURE' } }
+    it 'should raise validation error without symbol' do
+      expect { spot_client_signed.cancel_replace(**params) }.to raise_error(Binance::RequiredParameterError)
+    end
+  end
+
+  context 'validation side' do
+    let(:params) { { symbol: 'BNBBUSD', side: '', type: 'LIMIT', cancelReplaceMode: 'STOP_ON_FAILURE' } }
+    it 'should raise validation error without side' do
+      expect { spot_client_signed.cancel_replace(**params) }.to raise_error(Binance::RequiredParameterError)
+    end
+  end
+
+  context 'validation type' do
+    let(:params) { { symbol: 'BNBBUSD', side: 'BUY', type: '', cancelReplaceMode: 'STOP_ON_FAILURE' } }
+    it 'should raise validation error without type' do
+      expect { spot_client_signed.cancel_replace(**params) }.to raise_error(Binance::RequiredParameterError)
+    end
+  end
+
+  context 'validation cancelReplaceMode' do
+    let(:params) { { symbol: 'BNBBUSD', side: 'BUY', type: '', cancelReplaceMode: 'STOP_ON_FAILURE' } }
+    it 'should raise validation error without cancelReplaceMode' do
+      expect { spot_client_signed.cancel_replace(**params) }.to raise_error(Binance::RequiredParameterError)
+    end
+  end
+
+  context 'with parameters' do
+    let(:params) do
+      {
+        symbol: 'BNBBUSD',
+        side: 'BUY',
+        type: 'LIMIT',
+        cancelReplaceMode: 'STOP_ON_FAILURE',
+        quantity: 1,
+        timeInForce: 'GTC',
+        cancelOrderId: 'my_order_1',
+        recvWindow: 2_000
+      }
+    end
+    it 'should create a new order' do
+      spot_client_signed.cancel_replace(**params)
+      expect(send_a_request_with_signature(:post, path, params)).to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
### Add
- Sub account endpoints
  - `POST /sapi/v1/sub-account/subAccountApi/ipRestriction` to support master account enable and disable IP restriction for a sub-account API Key
  - `POST /sapi/v1/sub-account/subAccountApi/ipRestriction/ipList` to support master account add IP list for a sub-account API Key
  - `GET /sapi/v1/account/apiRestrictions/ipRestriction` to support master account query IP restriction for a sub-account API Key
  - `DELETE /sapi/v1/account/apiRestrictions/ipRestriction/ipList` to support master account delete IP list for a sub-account API Key
- Market endpoint
  - `GET /api/v3/ticker`
- Trade endpoint
  - `POST /api/v3/order/cancelReplace`
- Websocket methods
  - `<symbol>@ticker_<window_size>`
  - `!ticker_<window-size>@arr`