### PR TITLE
v1.3.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Publish Gem
+
+on:
+  release:
+    types:
+      - published
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby 3.1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.0
+
+      - name: Release Gem
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
+          gem build ruby-gem-release-test.gemspec
+          gem push *.gem
+        env:
+          RUBYGEMS_VERSION: "${{github.event.inputs.version}}"
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
       uses: actions/setup-ruby@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.3.0 - 2022-07-21
+
+### Add
+- New endpoint for Margin:
+  - `POST /sapi/v3/asset/getUserAsset` to get user assets.
+- New endpoint for Wallet:
+  - `GET /sapi/v1/margin/dribblet` to query the historical information of user's margin account small-value asset conversion BNB.
+
+
 ## 1.2.0 - 2022-07-15
 
 ### Add

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    binance-connector-ruby (1.1.0)
+    binance-connector-ruby (1.2.0)
       faraday (~> 1.8)
       websocket-eventmachine-client (~> 1.3)
 

--- a/examples/spot/margin/get_margin_dust_log.rb
+++ b/examples/spot/margin/get_margin_dust_log.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift('./lib')
+
+require 'binance'
+require_relative '../../common'
+
+logger = Common.setup_logger
+
+# set key here
+# or BINANCE_PUBLIC_API_KEY in env
+client = Binance::Spot.new(key: '', secret: '')
+
+logger.info(client.get_margin_dust_log)

--- a/examples/spot/wallet/get_user_asset.rb
+++ b/examples/spot/wallet/get_user_asset.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift('./lib')
+
+require 'binance'
+require_relative '../../common'
+
+logger = Common.setup_logger
+
+client = Binance::Spot.new(key: '', secret: '')
+logger.info(client.get_user_asset(asset: 'BNB', needBtcValuation: true))

--- a/lib/binance/spot/margin.rb
+++ b/lib/binance/spot/margin.rb
@@ -725,6 +725,19 @@ module Binance
       def get_margin_order_usage(**kwargs)
         @session.sign_request(:get, '/sapi/v1/margin/rateLimit/order', params: kwargs)
       end
+
+      # Margin Dustlog (USER_DATA)
+      #
+      # GET /sapi/v1/margin/dribblet
+      #
+      # @param kwargs [Hash]
+      # @option kwargs [String] :startTime
+      # @option kwargs [String] :endTime
+      # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
+      # @see https://binance-docs.github.io/apidocs/spot/en/#margin-dustlog-user_data
+      def get_margin_dust_log(**kwargs)
+        @session.sign_request(:get, '/sapi/v1/margin/dribblet', params: kwargs)
+      end
     end
   end
 end

--- a/lib/binance/spot/wallet.rb
+++ b/lib/binance/spot/wallet.rb
@@ -311,6 +311,19 @@ module Binance
       def api_key_permission(**kwargs)
         @session.sign_request(:get, '/sapi/v1/account/apiRestrictions', params: kwargs)
       end
+
+      # User Asset (USER_DATA)
+      #
+      # POST /sapi/v3/asset/getUserAsset
+      #
+      # @param kwargs [Hash]
+      # @option kwargs [String] :asset If asset is blank, then query all positive assets user have.
+      # @option kwargs [Boolean] :needBtcValuation
+      # @option kwargs [Integer] :recvWindow The value cannot be greater than 60000
+      # @see https://binance-docs.github.io/apidocs/spot/en/#user-asset-user_data
+      def get_user_asset(**kwargs)
+        @session.sign_request(:post, '/sapi/v3/asset/getUserAsset', params: kwargs)
+      end
     end
   end
 end

--- a/lib/binance/version.rb
+++ b/lib/binance/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Binance
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end

--- a/spec/binance/spot/margin/get_margin_dust_log_spec.rb
+++ b/spec/binance/spot/margin/get_margin_dust_log_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Binance::Spot::Margin, '#get_margin_dust_log' do
+  let(:path) { '/sapi/v1/margin/dribblet' }
+  let(:body) { fixture('response.json') }
+  let(:status) { 200 }
+  let(:params) do
+    {
+      startTime: 1_631_688_673_000,
+      endTime: 1_631_688_673_001
+    }
+  end
+
+  before do
+    mocking_signature_and_ts(**params)
+    stub_binance_sign_request(:get, path, status, body, params)
+  end
+
+  context 'with symbol' do
+    it 'should return margin dust convert history' do
+      spot_client_signed.get_margin_dust_log(**params)
+      expect(send_a_request_with_signature(:get, path, params)).to have_been_made
+    end
+  end
+end

--- a/spec/binance/spot/wallet/get_user_asset_spec.rb
+++ b/spec/binance/spot/wallet/get_user_asset_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Binance::Spot::Wallet, '#get_user_asset' do
+  let(:path) { '/sapi/v3/asset/getUserAsset' }
+  let(:body) { fixture('response.json') }
+  let(:status) { 200 }
+  let(:params) { {} }
+
+  before do
+    mocking_signature_and_ts(**params)
+    stub_binance_sign_request(:post, path, status, body, params)
+  end
+
+  context 'with parameters' do
+    let(:params) do
+      {
+        asset: 'BNB',
+        needBtcValuation: true
+      }
+    end
+    it 'should return user\'s asset list ' do
+      spot_client_signed.get_user_asset(**params)
+      expect(send_a_request_with_signature(:post, path, params)).to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
### Add
- New endpoint for Margin:
  - `POST /sapi/v3/asset/getUserAsset` to get user assets.
- New endpoint for Wallet:
  - `GET /sapi/v1/margin/dribblet` to query the historical information of user's margin account small-value asset conversion BNB.