### PR TITLE
Fetch ticker prices given symbols

### DIFF
--- a/lib/binance/spot/market.rb
+++ b/lib/binance/spot/market.rb
@@ -194,10 +194,17 @@ module Binance
       #
       # @param symbol [String] the symbol
       # @see https://binance-docs.github.io/apidocs/spot/en/#symbol-price-ticker
-      def ticker_price(symbol: nil)
+      def ticker_price(symbol: nil, symbols: nil)
+        params = { symbol: symbol }
+
+        if symbols
+          symbols = symbols.map { |s| "\"#{s}\"" }.join(',')
+          params = { symbols: "\[#{symbols}\]".upcase }
+        end
+
         @session.public_request(
           path: '/api/v3/ticker/price',
-          params: { symbol: symbol }
+          params: params
         )
       end
 

--- a/spec/binance/spot/market/ticker_price_spec.rb
+++ b/spec/binance/spot/market/ticker_price_spec.rb
@@ -26,4 +26,12 @@ RSpec.describe Binance::Spot::Market, '#ticker_price' do
       expect(send_a_request(:get, path)).to have_been_made
     end
   end
+
+  context 'with symbols' do
+    let(:path) { '/api/v3/ticker/price?symbols=["BNBBUSD","BNBUSDT"]' }
+    it 'should return 2 symbols ticker prices' do
+      spot_client.ticker_price(symbols: %w[BNBBUSD BNBUSDT])
+      expect(send_a_request(:get, path)).to have_been_made
+    end
+  end
 end


### PR DESCRIPTION
We were missing ticker prices from symbols
as the API interface provides this ability.

https://binance-docs.github.io/apidocs/spot/en/#symbol-price-ticker