### PR TITLE
Add proxy option when connecting to rest api

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ It's recommended to pass in the `base_url` parameter, even in production as Bina
 - `https://api2.binance.com`
 - `https://api3.binance.com`
 
+### Proxy
+
+If you need to use a proxy you can define `proxy_url`
+
+```
+client = Binance::Spot.new(base_url: 'https://api1.binance.com', proxy_url: 'http://myproxy.com')
+```
+
 ### RSA Signature
 
 Binance support both HMAC and RSA signature. Please find the example at `examples/trade/account.rb` for how to sign in both solutions.

--- a/lib/binance/session.rb
+++ b/lib/binance/session.rb
@@ -11,6 +11,7 @@ module Binance
 
     def initialize(options = {})
       @base_url = options[:base_url] || 'https://api.binance.com'
+      @proxy_url = options[:proxy_url]
       @auth = Authentication.new(options[:key], options[:secret], options[:private_key], options[:private_key_pass_phrase])
       @logger = options[:logger]
       @show_weight_usage = options[:show_weight_usage] || false
@@ -84,7 +85,9 @@ module Binance
     end
 
     def build_connection
-      Faraday.new(url: @base_url) do |client|
+      params = { url: @base_url }
+      params.merge!(proxy: @proxy_url) if @proxy_url
+      Faraday.new(params) do |client|
         prepare_headers(client)
         client.options.timeout = @timeout
         client.options.params_encoder = Binance::Utils::Faraday::CustomParamsEncoder

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Session < Binance::Session
-  attr_reader :base_url, :headers, :auth, :logger, :show_weight_usage, :show_header, :timeout
+  attr_reader :base_url, :proxy_url, :headers, :auth, :logger, :show_weight_usage, :show_header, :timeout
 end
 
 RSpec.describe Binance::Session do
@@ -9,6 +9,7 @@ RSpec.describe Binance::Session do
     where(:options, :expected_options) do
       [
         [{ base_url: 'base_url' }, { base_url: 'base_url', auth: Binance::Authentication.new(nil, nil), show_weight_usage: false, show_header: false, timeout: nil }],
+        [{ base_url: 'base_url', proxy_url: 'proxy_url' }, { base_url: 'base_url', proxy_url: 'proxy_url', auth: Binance::Authentication.new(nil, nil), show_weight_usage: false, show_header: false, timeout: nil }],
         [{ key: 'key', secret: 'secret' }, { base_url: 'https://api.binance.com', auth: Binance::Authentication.new('key', 'secret'), show_weight_usage: false, show_header: false, timeout: nil }],
         [{ show_weight_usage: true }, { base_url: 'https://api.binance.com', auth: Binance::Authentication.new(nil, nil), show_weight_usage: true, show_header: false, timeout: nil }],
         [{ show_header: true }, { base_url: 'https://api.binance.com', auth: Binance::Authentication.new(nil, nil), show_weight_usage: false, show_header: true, timeout: nil }],
@@ -19,6 +20,7 @@ RSpec.describe Binance::Session do
       subject { Session.new(options) }
       it 'include the updated options' do
         expect(subject.base_url).to eq(expected_options[:base_url])
+        expect(subject.proxy_url).to eq(expected_options[:proxy_url])
         expect(subject.auth.key).to eq(expected_options[:auth].key)
         expect(subject.auth.secret).to eq(expected_options[:auth].secret)
         expect(subject.logger).to eq(nil)
@@ -33,12 +35,37 @@ RSpec.describe Binance::Session do
     subject { Session.new({ logger: Logger.new($stdout) }) }
     it 'include the updated options' do
       expect(subject.base_url).to eq('https://api.binance.com')
+      expect(subject.proxy_url).to eq(nil)
       expect(subject.auth.key).to eq(nil)
       expect(subject.auth.secret).to eq(nil)
       expect(subject.logger).to be_a(Logger)
       expect(subject.show_weight_usage).to eq(false)
       expect(subject.show_header).to eq(false)
       expect(subject.timeout).to eq(nil)
+    end
+  end
+
+  context 'when init with proxy' do
+    before do
+      allow(Faraday).to receive(:new).with(url: 'https://api.binance.com', proxy: 'proxy_url')
+    end
+
+    subject { Session.new(proxy_url: 'proxy_url' ) }
+    it 'include the proxy options' do
+      subject.send(:build_connection)
+      expect(Faraday).to have_received(:new).with(url: 'https://api.binance.com', proxy: 'proxy_url')
+    end
+  end
+
+  context 'when init without proxy' do
+    before do
+      allow(Faraday).to receive(:new).with(url: 'https://api.binance.com')
+    end
+
+    subject { Session.new( url: 'test') }
+    it 'not include the proxy options' do
+      subject.send(:build_connection)
+      expect(Faraday).to have_received(:new).with(url: 'https://api.binance.com')
     end
   end
 end


### PR DESCRIPTION
closes #15 

This PR implements a way to setup the connection through a proxy as discussed in the issue #15 
